### PR TITLE
Fixed typo to support client certs

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -357,7 +357,7 @@ which are not meant as separators."
     (cl+ssl:make-ssl-client-stream
      (cl+ssl:stream-fd s)
      :close-callback (lambda () (close s))
-     :certificate certificate-password
+     :certificate certificate
      :key key
      :password certificate-password))
   #+:drakma-no-ssl


### PR DESCRIPTION
Fixed the problem that I described here

http://lists.common-lisp.net/pipermail/drakma-devel/2012-January/000894.html
