### PR TITLE
disect-query now respects query values containing the = character

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -363,10 +363,16 @@ which are not meant as separators."
   #+:drakma-no-ssl
   (error "SSL not supported. Remove :drakma-no-ssl from *features* to enable SSL"))
 
+(defun split-parameter-pair (parameter-pair)
+  "Splits a parameter pair, a string of the form k=v, into a list of the strings k and v."
+  (let ((p (position #\= parameter-pair)))
+    (if p (list (subseq parameter-pair 0 p) (subseq parameter-pair (1+ p)))
+	(list parameter-pair))))
+
 (defun dissect-query (query-string)
   "Accepts a query string as in PURI:URI-QUERY and returns a
 corresponding alist of name/value pairs."
   (when query-string
     (loop for parameter-pair in (split-string query-string "&")
-          for (name value) = (split-string parameter-pair "=")
+          for (name value) = (split-parameter-pair parameter-pair)
           collect (cons name value))))


### PR DESCRIPTION
Hans,

I had some problems using drakma to call a web service that required me to pass a hash code as a query parameter. The hash code included an equals sign character as its terminator, and drakma was stripping this character off rather than sending it to the server.

I've modified disect-query to call a new function split-parameter-pair, instead of split-string, which was greedily consuming the equals sign character.

Thanks!

Rob.
