### PR TITLE
Preserve uri when following redirect

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -769,6 +769,7 @@ PARAMETERS will not be used."
                                               :additional-headers additional-headers
                                               ;; don't send GET parameters again in redirect
                                               :parameters (and (not (eq method :get)) parameters)
+                                              :preserve-uri t
                                               args)))))
                                (let ((transfer-encodings (header-value :transfer-encoding headers)))
                                  (when transfer-encodings


### PR DESCRIPTION
I had a problem when using cl-selenium, because there was always a redirect and the get parameters would always be encoded twice.
After some investigation i found out that drakma encoded the get parameters twice. When I added preserve uri to the call to http-request when redirecting, this issue was resolved.
