### PR TITLE
Fix the computation of Content-Length

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -663,18 +663,17 @@ PARAMETERS will not be used."
                 (when (and content-length
                            (not (or (and (integerp content-length)
                                          (not (minusp content-length)))
-                                    (arrayp content)
-                                    (listp content)
+                                    (typep content '(or (vector octet) list))
                                     (eq content :continuation))))
                   ;; CONTENT-LENGTH forces us to compute request body
                   ;; in RAM
                   (setq content
                         (with-output-to-sequence (bin-out)
                           (let ((out (make-flexi-stream bin-out :external-format +latin-1+)))
-                            (send-content content out)))))
+                            (send-content content out external-format-out)))))
                 (when (and (or (not content-length-provided-p)
                                (eq content-length t))
-                           (or (arrayp content) (listp content)))
+                           (typep content '(or (vector octet) list)))
                   (setq content-length (length content)))
                 (cond (content-length
                        (write-header "Content-Length" "~D" content-length))


### PR DESCRIPTION
If the :CONTENT keyword argument of HTTP-REQUEST is a string, the number of the characters in the string is used as Content-Length, not the number of the octets. It causes lack of part of input data.

repro code and result: https://gist.github.com/3701770
