### PR TITLE
fix handling of Content-Length

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -668,11 +668,13 @@ PARAMETERS will not be used."
               (when content
                 (when content-type
                   (write-header "Content-Type" "~A" content-type))
-                (when (and content-length
-                           (not (or (and (integerp content-length)
-                                         (not (minusp content-length)))
-                                    (typep content '(or (vector octet) list))
-                                    (eq content :continuation))))
+                (when (or (and (not content-length-provided-p)
+                               (stringp content))
+                          (and content-length
+                               (not (or (and (integerp content-length)
+                                             (not (minusp content-length)))
+                                        (typep content '(or (vector octet) list))
+                                        (eq content :continuation)))))
                   ;; CONTENT-LENGTH forces us to compute request body
                   ;; in RAM
                   (setq content


### PR DESCRIPTION
I fixed the computation of Content-Length in 1134506. But the commit introduced an unexpected backward incompatibility.

If a string is provided as the :content keyword argument of http-request and  the :content-length keyword argument is not provided, the revision 1134506 and later don't output Content-Length. But the revisions older than 1134506 output Content-Length under the same conditions (though it's not correct length).

This pull request is a fix for the above. Could you review this request?
