### PR TITLE
This patch further improves Drakma behavior in case of Redirect-to-Get 

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -38,7 +38,7 @@
 
 (in-package :drakma-asd)
 
-(defvar *drakma-version-string* "1.3.1"
+(defvar *drakma-version-string* "1.3.2"
   "Drakma's version number as a string.")
 
 ;; we export its name so we can import it later

--- a/request.lisp
+++ b/request.lisp
@@ -245,7 +245,7 @@ PROTOCOL is the HTTP protocol which is going to be used in the
 request line, it must be one of the keywords :HTTP/1.0 or
 :HTTP/1.1.  METHOD is the method used in the request line, a
 keyword \(like :GET or :HEAD) denoting a valid HTTP/1.1 or WebDAV
-request method, or :REPORT, as described in the Versioning 
+request method, or :REPORT, as described in the Versioning
 Extensions to WebDAV.  Additionally, you can also use the pseudo
 method :OPTIONS* which is like :OPTIONS but means that an
 \"OPTIONS *\" request line will be sent, i.e. the URI's path and
@@ -702,7 +702,7 @@ PARAMETERS will not be used."
               (force-output http-stream)
               (when (and content (null content-length))
                 (setf (chunked-stream-output-chunking-p
-                       (flexi-stream-stream http-stream)) t))         
+                       (flexi-stream-stream http-stream)) t))
               (labels ((finish-request (content &optional continuep)
                          (send-content content http-stream external-format-out)
                          (when continuep
@@ -776,8 +776,10 @@ PARAMETERS will not be used."
                                        (ignore-errors (close http-stream)))
                                      (setq done t)
                                      (return-from http-request
-                                       (let ((method (cond ((member status-code +redirect-to-get-codes+) :get)
-                                                           (t method))))
+                                       (let ((method (if (and (member status-code +redirect-to-get-codes+)
+                                                              (member method +redirect-to-get-methods+))
+                                                         :get
+                                                         method)))
                                          (apply #'http-request new-uri
                                                 :method method
                                                 :redirect (cond ((integerp redirect) (1- redirect))

--- a/specials.lisp
+++ b/specials.lisp
@@ -42,10 +42,10 @@
   "A list of all HTTP return codes that redirect us to another URI.")
 
 (define-constant +redirect-to-get-codes+ '(302 303)
-  "A list of HTTP return codes that redirect using a GET method.")
+  "A list of HTTP return codes that redirect using a GET method
+(see http://en.wikipedia.org/wiki/Post/Redirect/Get).")
 
 (define-constant +known-methods+ '(:copy
-                                   :delete
                                    :delete
                                    :get
                                    :head
@@ -63,6 +63,10 @@
                                    :trace
                                    :unlock)
   "The HTTP methods \(including WebDAV methods) Drakma knows.")
+
+(define-constant +redirect-to-get-methods+ '(:post)
+  "A list of HTTP methods that should be changed to GET in case of redirect
+(see http://en.wikipedia.org/wiki/Post/Redirect/Get).")
 
 (defconstant +buffer-size+ 8192)
 
@@ -262,4 +266,3 @@ timezones.")
     (cdr (assoc symbol
                 exported-symbols-alist
                 :test #'eq))))
-               


### PR DESCRIPTION
Now Drakma doesn't change the method unless the method is supposed to change (probably, only POST should change).

The current behavior is unsatisfactory for example for HEAD requests. See a snippet of headers below:

```
CL-USER> (drakma:http-request "http://sourceforge.net/projects/wnsql/files/wnsql-1.0.1/wordnet30-sqlite-1.0.1.zip/download" :method :head)
HEAD /projects/wnsql/files/wnsql-1.0.1/wordnet30-sqlite-1.0.1.zip/download HTTP/1.1
Host: sourceforge.net
User-Agent: Drakma/1.3.0 (SBCL 1.0.55.0.debian; Linux; 3.2.0-23-generic; http://weitz.de/drakma/)
Accept: */*
Connection: close

HTTP/1.1 302 Found
Server: nginx/0.8.54
Date: Wed, 10 Apr 2013 17:42:40 GMT
Content-Type: text/html; charset=UTF-8
Connection: close
....

GET /project/wnsql/wnsql-1.0.1/wordnet30-sqlite-1.0.1.zip?r=&ts=1365615760&use_mirror=freefr HTTP/1.1
...
```
