### PR TITLE
Change handling of empty and missing Location headers

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -735,7 +735,8 @@ PARAMETERS will not be used."
                                (when cookie-jar
                                  (update-cookies (get-cookies headers uri) cookie-jar))
                                (when (and redirect
-                                          (member status-code +redirect-codes+))
+                                          (member status-code +redirect-codes+)
+                                          (header-value :location headers))
                                  (unless (or (eq redirect t)
                                              (and (integerp redirect)
                                                   (plusp redirect)))
@@ -747,14 +748,7 @@ PARAMETERS will not be used."
                                  (when auto-referer
                                    (setq additional-headers (set-referer uri additional-headers)))
                                  (let* ((location (header-value :location headers))
-                                        (new-uri (merge-uris
-                                                  (cond ((or (null location)
-                                                             (zerop (length location)))
-                                                         (drakma-warn
-                                                          "Empty `Location' header, assuming \"/\".")
-                                                         "/")
-                                                        (t location))
-                                                  uri))
+                                        (new-uri (merge-uris location uri))
                                         ;; can we re-use the stream?
                                         (old-server-p (and (string= (uri-host new-uri)
                                                                     (uri-host uri))


### PR DESCRIPTION
Drakma at the moment handles both missing and empty Location headers the same way, by redirecting to the host. This is wrong for empty Location headers, and inconvenient for missing ones.

For context, there are extended discussions of how different browsers handle the problem in these Mozilla bugs:

https://bugzilla.mozilla.org/show_bug.cgi?id=742508
https://bugzilla.mozilla.org/show_bug.cgi?id=742174

In short, there’s nothing invalid about a blank location header; it’s equivalent to a redirect to the same URI.

As for a missing Location header, I think the best thing is to return the body, on the general principle that it’s best to handle errors in the way that destroys the least information.

This is a real problem, not a quibble. At TBRSS I’m running into what I think are botched attempts at Feedburner redirects. They return 302, but with no Location header, and so, instead of the feed, Drakma returns the blog itself.
