### PR TITLE
Added *no-proxy-domains*.

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -38,6 +38,7 @@
            #:*body-format-function*
            #:*remove-duplicate-cookies-p*
            #:*default-http-proxy*
+           #:*no-proxy-domains*
            #:*drakma-default-external-format*
            #:*header-stream*
            #:*ignore-unparseable-cookie-dates-p*

--- a/specials.lisp
+++ b/specials.lisp
@@ -260,6 +260,9 @@ otherwise).")
 ;; and <http://www.cliki.net/hyperdoc>
 ;; also used by LW-ADD-ONS
 
+(defvar *no-proxy-domains* nil
+  "A list of domains for which a proxy should not be used.")
+
 (defvar *hyperdoc-base-uri* "http://weitz.de/drakma/")
 
 (let ((exported-symbols-alist


### PR DESCRIPTION
Proxy whitelist will allow you to specify a list of hosts which will
not be subjected to being routed via the specified proxy.
