### PR TITLE
Make POST requests use external-format-out for multipart/form-data.

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -111,7 +111,7 @@ body using the boundary BOUNDARY."
                  (crlf) (crlf)
                  (setf (flexi-stream-external-format stream) external-format-out)
                  (format stream "~A" value)
-                 (setf (flexi-stream-external-format stream) +latin-1+)                 
+                 (setf (flexi-stream-external-format stream) +latin-1+))
                 ((and (listp value)
                       (first value)
                       (not (stringp (first value))))


### PR DESCRIPTION
With this change, POST requests that use multipart/form-data will use
external-format-out for encoding, instead of :latin-1. Without this
change, an attempt to use characters outside the :latin-1 range (e.g,
U+2011, "n-dash") would cause an exception while building the request.

Note: it would be possible to only do this for strings that have
characters that are not standard-char.

Example/test case:

(handler-bind 
    ((error (lambda (condition) (break))))
  (drakma:http-request "http://some.server/some/path"
                       :method :post
                       :external-format-in :utf-8
                       :external-format-out :utf-8
                       :parameters (list 
                                    (cons "file" #p"some/local/file")
                                    (cons "foo" (string (code-char 8211))))))

--- modify to use a reachable web server and existing file.
