### PR TITLE
Prefix all puri symbols.

### DIFF
--- a/cookies.lisp
+++ b/cookies.lisp
@@ -110,7 +110,7 @@ every domain name is considered acceptable."
 
 (defun cookie-domain-matches (domain uri)
   "Checks if the domain DOMAIN \(a string) matches the \(PURI) URI URI."
-  (ends-with-p (normalize-cookie-domain (uri-host uri))
+  (ends-with-p (normalize-cookie-domain (puri:uri-host uri))
                (normalize-cookie-domain domain)))
 
 (defun send-cookie-p (cookie uri force-ssl)
@@ -120,7 +120,7 @@ in HTTP-REQUEST)."
   (and ;; check domain
        (cookie-domain-matches (cookie-domain cookie) uri)
        ;; check path
-       (starts-with-p (or (uri-path uri) "/") (cookie-path cookie))
+       (starts-with-p (or (puri:uri-path uri) "/") (cookie-path cookie))
        ;; check expiry date
        (let ((expires (cookie-expires cookie)))
          (or (null expires)
@@ -128,7 +128,7 @@ in HTTP-REQUEST)."
        ;; check if connection must be secure       
        (or (null (cookie-securep cookie))
            force-ssl
-           (eq (uri-scheme uri) :https))))
+           (eq (puri:uri-scheme uri) :https))))
 
 (defun check-cookie (cookie)
   "Checks if the slots of the COOKIE object COOKIE have valid values
@@ -285,14 +285,14 @@ the \(PURI) URI URI."
         with parsed-cookies = (and set-cookie-header (parse-set-cookie set-cookie-header))
         for (name value parameters) in parsed-cookies
         for expires = (parameter-value "expires" parameters)
-        for domain = (or (parameter-value "domain" parameters) (uri-host uri))
+        for domain = (or (parameter-value "domain" parameters) (puri:uri-host uri))
         when (and (valid-cookie-domain-p domain)
                   (cookie-domain-matches domain uri))
         collect (make-instance 'cookie
                                :name name
                                :value value
                                :path (or (parameter-value "path" parameters)
-                                         (uri-path uri)
+                                         (puri:uri-path uri)
                                          "/")
                                :expires (and expires
                                              (plusp (length expires))

--- a/packages.lisp
+++ b/packages.lisp
@@ -30,7 +30,7 @@
 (in-package :cl-user)
 
 (defpackage :drakma
-  (:use :cl :puri :flexi-streams :chunga)
+  (:use :cl :flexi-streams :chunga)
   ;; the variable defined in the ASDF system definition
   (:import-from :drakma-asd #:*drakma-version-string*)
   (:shadow #:syntax-error #:parameter-error)

--- a/request.lisp
+++ b/request.lisp
@@ -469,12 +469,12 @@ request is not a POST with a content-type of `multipart/form-data',
 PARAMETERS will not be used."
   (unless (member protocol '(:http/1.0 :http/1.1) :test #'eq)
     (parameter-error "Don't know how to handle protocol ~S." protocol))
-  (setq uri (cond ((uri-p uri) (copy-uri uri))
-                  (t (parse-uri uri))))
+  (setq uri (cond ((puri:uri-p uri) (puri:copy-uri uri))
+                  (t (puri:parse-uri uri))))
   (unless (member method +known-methods+ :test #'eq)
     (parameter-error "Don't know how to handle method ~S." method))
-  (unless (member (uri-scheme uri) '(:http :https) :test #'eq)
-    (parameter-error "Don't know how to handle scheme ~S." (uri-scheme uri)))
+  (unless (member (puri:uri-scheme uri) '(:http :https) :test #'eq)
+    (parameter-error "Don't know how to handle scheme ~S." (puri:uri-scheme uri)))
   (when (and close keep-alive)
     (parameter-error "CLOSE and KEEP-ALIVE must not be both true."))
   (when (and form-data (not (member method '(:post :report) :test #'eq)))
@@ -493,7 +493,7 @@ PARAMETERS will not be used."
     (when (atom proxy)
       (setq proxy (list proxy 80))))
   ;; Ignore the proxy for whitelisted hosts.
-  (when (member (uri-host uri) no-proxy-domains :test #'string=)
+  (when (member (puri:uri-host uri) no-proxy-domains :test #'string=)
     (setq proxy '()))
   ;; make sure we don't get :CRLF on Windows
   (let ((*default-eol-style* :lf)
@@ -525,13 +525,13 @@ PARAMETERS will not be used."
       (unwind-protect
           (progn
             (let ((host (or (and proxy (first proxy))
-                            (uri-host uri)))
+                            (puri:uri-host uri)))
                   (port (cond (proxy (second proxy))
-                              ((uri-port uri))
+                              ((puri:uri-port uri))
                               (t (default-port uri))))
                   (use-ssl (and (not proxying-https-p)
                                 (or force-ssl
-                                    (eq (uri-scheme uri) :https)))))
+                                    (eq (puri:uri-scheme uri) :https)))))
               #+(and :lispworks5.0 :mswindows
                      (not :lw-does-not-have-write-timeout))
               (when use-ssl
@@ -602,9 +602,9 @@ PARAMETERS will not be used."
                 ;; set up a tunnel through the proxy server to the
                 ;; final destination
                 (write-http-line "CONNECT ~A:~:[443~;~:*~A~] HTTP/1.1"
-                                 (uri-host uri) (uri-port uri))
+                                 (puri:uri-host uri) (puri:uri-port uri))
                 (write-http-line "Host: ~A:~:[443~;~:*~A~]"
-                                 (uri-host uri) (uri-port uri))
+                                 (puri:uri-host uri) (puri:uri-port uri))
                 (write-http-line "")
                 (force-output http-stream)
                 ;; check we get a 200 response before proceeding
@@ -619,33 +619,33 @@ PARAMETERS will not be used."
                 (setq http-stream (wrap-stream (make-ssl-stream raw-http-stream))))
               (when-let (all-get-parameters
                          (and (not preserve-uri)
-                              (append (dissect-query (uri-query uri))
+                              (append (dissect-query (puri:uri-query uri))
                                       (and (not parameters-used-p) parameters))))
-                (setf (uri-query uri)
+                (setf (puri:uri-query uri)
                       (alist-to-url-encoded-string all-get-parameters external-format-out url-encoder)))
               (when (eq method :options*)
                 ;; special pseudo-method
                 (setf method :options
-                      (uri-path uri) "*"
-                      (uri-query uri) nil))
+                      (puri:uri-path uri) "*"
+                      (puri:uri-query uri) nil))
               (write-http-line "~A ~A ~A"
                                (string-upcase method)
                                (if (and preserve-uri
                                         (stringp unparsed-uri))
                                    (trivial-uri-path unparsed-uri)
-                                   (render-uri (cond
+                                   (puri:render-uri (cond
                                                  ((and proxy
                                                        (null stream)
                                                        (not proxying-https-p)
                                                        (not real-host))
                                                   uri)
                                                  (t
-                                                  (make-instance 'uri
-                                                                 :path (or (uri-path uri) "/")
-                                                                 :query (uri-query uri))))
+                                                  (make-instance 'puri:uri
+                                                                 :path (or (puri:uri-path uri) "/")
+                                                                 :query (puri:uri-query uri))))
                                                nil))
                                (string-upcase protocol))
-              (write-header "Host" "~A~@[:~A~]" (uri-host uri) (non-default-port uri))
+              (write-header "Host" "~A~@[:~A~]" (puri:uri-host uri) (non-default-port uri))
               (when user-agent
                 (write-header "User-Agent" "~A" (user-agent-string user-agent)))
               (when basic-authorization
@@ -761,14 +761,14 @@ PARAMETERS will not be used."
                                  (when auto-referer
                                    (setq additional-headers (set-referer uri additional-headers)))
                                  (let* ((location (header-value :location headers))
-                                        (new-uri (merge-uris location uri))
+                                        (new-uri (puri:merge-uris location uri))
                                         ;; can we re-use the stream?
-                                        (old-server-p (and (string= (uri-host new-uri)
-                                                                    (uri-host uri))
-                                                           (eql (uri-port new-uri)
-                                                                (uri-port uri))
-                                                           (eq (uri-scheme new-uri)
-                                                               (uri-scheme uri)))))
+                                        (old-server-p (and (string= (puri:uri-host new-uri)
+                                                                    (puri:uri-host uri))
+                                                           (eql (puri:uri-port new-uri)
+                                                                (puri:uri-port uri))
+                                                           (eq (puri:uri-scheme new-uri)
+                                                               (puri:uri-scheme uri)))))
                                    (unless old-server-p
                                      (setq must-close t
                                            want-stream nil))

--- a/util.lisp
+++ b/util.lisp
@@ -129,7 +129,7 @@ value with a #\\= character.  If the value is NIL, no #\\= is used."
 (defun default-port (uri)
   "Returns the default port number for the \(PURI) URI URI.
 Works only with the http and https schemes."
-  (ecase (uri-scheme uri)
+  (ecase (puri:uri-scheme uri)
     (:http 80)
     (:https 443)))
 
@@ -137,7 +137,7 @@ Works only with the http and https schemes."
   "If the \(PURI) URI specifies an explicit port number which is
 different from the default port its scheme, this port number is
 returned, otherwise NIL."
-  (when-let (port (uri-port uri))
+  (when-let (port (puri:uri-port uri))
     (when (/= port (default-port uri))
       port)))
 


### PR DESCRIPTION
Hi Hans,

some of the symbols from puri are prefixed.

I think this is a good idea - I made a patch (semi-automatically)
to prefix all of them.

Also the symbol uri comes from puri, I left that one alone, because
it is mostly used as a variable name.

Except in one place, which has been changed to `make-instance 'puri:uri`.

I hope you like it and will pull it upstream :)

Best
Kilian
