### PR TITLE
Add SSL/TLS support for mocl

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -55,4 +55,4 @@
                :flexi-streams
                :cl-ppcre
                #-:lispworks :usocket
-               #-(or :lispworks :allegro :drakma-no-ssl) :cl+ssl))
+               #-(or :lispworks :allegro :mocl-ssl :drakma-no-ssl) :cl+ssl))

--- a/util.lisp
+++ b/util.lisp
@@ -328,7 +328,12 @@ which are not meant as separators."
                                  :max-depth max-depth
                                  :ca-file ca-file
                                  :ca-directory ca-directory)
-  #+(and (not :allegro) (not :drakma-no-ssl))
+  #+(and :mocl-ssl (not :drakma-no-ssl))
+  (progn
+    (when (or ca-file ca-directory)
+      (warn ":max-depth, :ca-file and :ca-directory arguments not available on this platform"))
+    (rt:start-ssl http-stream :verify verify))
+  #+(and (not :allegro) (not :mocl-ssl) (not :drakma-no-ssl))
   (let ((s http-stream))
     (when (or verify ca-file ca-directory)
       (warn ":verify, :max-depth, :ca-file and :ca-directory arguments not available on this platform"))


### PR DESCRIPTION
Hi Hans,

This patch adds support for SSL/TLS on mocl. Let me know if any questions/concerns about it.

Thanks,
Wes
