### PR TITLE
Do not escape URI twice.

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -637,8 +637,10 @@ PARAMETERS will not be used."
                                                              (not real-host))
                                                         uri
                                                         (make-instance 'puri:uri
-                                                                       :path (or (puri:uri-path uri) "/")
-                                                                       :query (puri:uri-query uri)))
+                                                                       :path (puri:uri-path uri)
+                                                                       :parsed-path (puri:uri-parsed-path uri)
+                                                                       :query (puri:uri-query uri)
+                                                                       :escaped t))
                                                     nil))
                                (string-upcase protocol))
               (write-header "Host" "~A~@[:~A~]" (puri:uri-host uri) (non-default-port uri))


### PR DESCRIPTION
Drakma escapes URI twice when using `puri-unicode`.

```
(http-request "http://fr.wikipedia.org/wiki/Père")
```

results in

```
GET /wiki/P%25c3%25a8re HTTP/1.1
```

instead of

```
GET /wiki/P%c3%a8re HTTP/1.1
```

What happens with `puri-unicode` is that:
1. drakma calls make-instance 'puri:uri
2. initialize-instance computes uri-parsed-path because it was not provided to make-instance. It does this incorrectly, treating uri-path as being unescaped, thereas it either was already escaped, or is unaffected by escaping.
3. initialize-instance sets puri:uri-parsed-path to the computed (wrong) value
4. setting puri:uri-parsed-path recomputes and resets puri:uri-path to a wrong value

 Old `puri` is not affected just because it is does not compute uri-parsed-path preemptively (https://github.com/archimag/puri-unicode/blob/f5176bf4c8e05069d5ef1040df8489f686f73ac2/src.lisp#L252), and Drakma does not happen to trigger the code path that would corrupt URI. My patch is correct with both editions of `puri`.

I replaced `(or (puri:uri-path uri) "/")` with `(puri:uri-path uri)` because `puri:render-uri` does this substitution itself.
