### PR TITLE
Make UTF-8 the default encoding

### DIFF
--- a/doc/index.xml
+++ b/doc/index.xml
@@ -1238,7 +1238,7 @@ T</span>
             arguments of <clix:ref>HTTP-REQUEST</clix:ref>.  The value
             of this variable will be interpreted by <a
             href="http://weitz.de/flexi-streams/">FLEXI-STREAMS</a>.
-            The initial value is the keyword <code>:LATIN-1</code>.
+            The initial value is the keyword <code>:UTF-8</code>.
             (Note that Drakma binds <a
             href="http://weitz.de/flexi-streams/#*default-eol-style*"><code>*DEFAULT-EOL-STYLE*</code></a>
             to <code>:LF</code>).

--- a/request.lisp
+++ b/request.lisp
@@ -52,7 +52,7 @@ depending on the type of CONTENT."
     (cond ((stringp content)
            (setf (flexi-stream-external-format stream) external-format-out)
            (write-string content stream)
-           (setf (flexi-stream-external-format stream) +latin-1+))
+           (setf (flexi-stream-external-format stream) +utf-8+))
           ((or (arrayp content) (listp content))
            (write-sequence content stream))
           ((and (streamp content)
@@ -99,7 +99,7 @@ body using the boundary BOUNDARY."
                  (crlf) (crlf)
                  (setf (flexi-stream-external-format stream) external-format-out)
                  (format stream "~A" value)
-                 (setf (flexi-stream-external-format stream) +latin-1+))
+                 (setf (flexi-stream-external-format stream) +utf-8+))
                 ((and (listp value)
                       (first value)
                       (not (stringp (first value))))
@@ -588,7 +588,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                        (write-http-line "~A: ~?" name value-fmt value-args))
                      (wrap-stream (http-stream)
                        (make-flexi-stream (make-chunked-stream http-stream)
-                                          :external-format +latin-1+)))
+                                          :external-format +utf-8+)))
               (when (and use-ssl
                          ;; don't attach SSL to existing streams
                          (not stream))
@@ -606,7 +606,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (cond (stream
                      (setf (flexi-stream-element-type http-stream)
                            #+:lispworks 'lw:simple-char #-:lispworks 'character
-                           (flexi-stream-external-format http-stream) +latin-1+))
+                           (flexi-stream-external-format http-stream) +utf-8+))
                     (t
                      (setq http-stream (wrap-stream http-stream))))
               (when proxying-https-p
@@ -709,7 +709,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                   ;; in RAM
                   (setq content
                         (with-output-to-sequence (bin-out)
-                          (let ((out (make-flexi-stream bin-out :external-format +latin-1+)))
+                          (let ((out (make-flexi-stream bin-out :external-format +utf-8+)))
                             (send-content content out external-format-out)))))
                 (when (and (or (not content-length-provided-p)
                                (eq content-length t))

--- a/specials.lisp
+++ b/specials.lisp
@@ -38,7 +38,7 @@
   `(defconstant ,name (if (boundp ',name) (symbol-value ',name) ,value)
      ,@(when doc (list doc))))
 
-(define-constant +latin-1+ (make-external-format :latin-1 :eol-style :lf)
+(define-constant +utf-8+ (make-external-format :utf-8 :eol-style :lf)
   "Default external format when reading headers.")
 
 (define-constant +redirect-codes+ '(301 302 303 307)
@@ -73,10 +73,10 @@
 
 (defconstant +buffer-size+ 8192)
 
-(defvar *drakma-default-external-format* ':latin-1
+(defvar *drakma-default-external-format* ':utf-8
   "The default value for the external format keyword arguments of
 HTTP-REQUEST.  The value of this variable will be interpreted by
-FLEXI-STREAMS.  The initial value is the keyword :LATIN-1.
+FLEXI-STREAMS.  The initial value is the keyword :UTF-8.
 (Note that Drakma binds *DEFAULT-EOL-STYLE* to :LF).")
 
 (defvar *header-stream* nil


### PR DESCRIPTION
It seems to me that nowadays UTF-8 is a far more sensible default encoding than Latin-1 (or anything else, for that matter…)
