### PR TITLE
Revert "Use quri instead of puri"

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -244,14 +244,14 @@ X-RateLimit-Remaining: 48
 X-RateLimit-Limit: 60
 Content-Length: 23
 X-Content-Type-Options: nosniff
-Cache-Control:
+Cache-Control: 
 </span>
 <span class="repl-output">#(123 34 109 101 115 115 97 103 101 34 58 34 78 111 116 32 70 111 117 110 100 34 125)
 404
 ((:SERVER . "nginx") (:DATE . "Fri, 28 Dec 2012 08:37:31 GMT") (:CONTENT-TYPE . "application/json; charset=utf-8")
  (:CONNECTION . "close") (:STATUS . "404 Not Found") (:X-GITHUB-MEDIA-TYPE . "github.beta") (:X-RATELIMIT-REMAINING . "48")
  (:X-RATELIMIT-LIMIT . "60") (:CONTENT-LENGTH . "23") (:X-CONTENT-TYPE-OPTIONS . "nosniff") (:CACHE-CONTROL . ""))
-#&lt;QURI:URI https://api.github.com/repos/edicl/drakma/git/tags/tag-does-not-exist&gt;
+#&lt;PURI:URI https://api.github.com/repos/edicl/drakma/git/tags/tag-does-not-exist&gt;
 #&lt;FLEXI-STREAMS:FLEXI-IO-STREAM {101C40C043}&gt;
 T
 "Not Found"</span>
@@ -343,7 +343,7 @@ Content-Length: 40
 </span>
 <span class="headers-in">HTTP/1.1 200 OK
 Date: Sun, 09 Dec 2012 08:25:13 GMT
-Server:
+Server:  
 X-Powered-By: PHP/5.2.17
 <b>Set-Cookie: PHPSESSID=vijk3706eojs7n8u5cdpi3ju05; path=/</b>
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
@@ -363,7 +363,7 @@ Connection: close
 </span>
 <span class="headers-in">HTTP/1.1 200 OK
 Date: Sun, 09 Dec 2012 08:25:16 GMT
-Server:
+Server:  
 X-Powered-By: PHP/5.2.17
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
@@ -723,7 +723,7 @@ T</span>
             request to a web server and returns its reply.
             <code xmlns=""><i>uri</i></code> is where the request is sent to,
             and it is either a string denoting a uniform resource
-            identifier or a <code>QURI:URI</code> object.  The scheme
+            identifier or a <code>PURI:URI</code> object.  The scheme
             of <code xmlns=""><i>uri</i></code> must be `http' or `https'.
             The function returns SEVEN values - the body of the
             reply<sup>0</sup> (but see below), the status
@@ -1405,7 +1405,7 @@ T</span>
             page</a> for the <code>HttpOnly</code> extension).
           </p>
           <pre xmlns="http://www.w3.org/1999/xhtml"><span class="repl-output">? </span><span class="repl-input">(make-instance 'drakma:cookie
-                 :name "Foo"
+                 :name "Foo" 
                  :value "Bar"
                  :expires (+ (get-universal-time) 3600)
                  :domain ".weitz.de")</span>

--- a/doc/index.xml
+++ b/doc/index.xml
@@ -211,14 +211,14 @@ X-RateLimit-Remaining: 48
 X-RateLimit-Limit: 60
 Content-Length: 23
 X-Content-Type-Options: nosniff
-Cache-Control:
+Cache-Control: 
 </span>
 <span class="repl-output">#(123 34 109 101 115 115 97 103 101 34 58 34 78 111 116 32 70 111 117 110 100 34 125)
 404
 ((:SERVER . "nginx") (:DATE . "Fri, 28 Dec 2012 08:37:31 GMT") (:CONTENT-TYPE . "application/json; charset=utf-8")
  (:CONNECTION . "close") (:STATUS . "404 Not Found") (:X-GITHUB-MEDIA-TYPE . "github.beta") (:X-RATELIMIT-REMAINING . "48")
  (:X-RATELIMIT-LIMIT . "60") (:CONTENT-LENGTH . "23") (:X-CONTENT-TYPE-OPTIONS . "nosniff") (:CACHE-CONTROL . ""))
-#&lt;QURI:URI https://api.github.com/repos/edicl/drakma/git/tags/tag-does-not-exist&gt;
+#&lt;PURI:URI https://api.github.com/repos/edicl/drakma/git/tags/tag-does-not-exist&gt;
 #&lt;FLEXI-STREAMS:FLEXI-IO-STREAM {101C40C043}&gt;
 T
 "Not Found"</span>
@@ -311,7 +311,7 @@ Content-Length: 40
 </span>
 <span class="headers-in">HTTP/1.1 200 OK
 Date: Sun, 09 Dec 2012 08:25:13 GMT
-Server:
+Server:  
 X-Powered-By: PHP/5.2.17
 <b>Set-Cookie: PHPSESSID=vijk3706eojs7n8u5cdpi3ju05; path=/</b>
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
@@ -331,7 +331,7 @@ Connection: close
 </span>
 <span class="headers-in">HTTP/1.1 200 OK
 Date: Sun, 09 Dec 2012 08:25:16 GMT
-Server:
+Server:  
 X-Powered-By: PHP/5.2.17
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
@@ -702,7 +702,7 @@ T</span>
             request to a web server and returns its reply.
             <clix:arg>uri</clix:arg> is where the request is sent to,
             and it is either a string denoting a uniform resource
-            identifier or a <code>QURI:URI</code> object.  The scheme
+            identifier or a <code>PURI:URI</code> object.  The scheme
             of <clix:arg>uri</clix:arg> must be `http' or `https'.
             The function returns SEVEN values - the body of the
             reply<sup>0</sup> (but see below), the status
@@ -1401,7 +1401,7 @@ T</span>
             page</a> for the <code>HttpOnly</code> extension).
           </p>
           <pre><span class="repl-output">? </span><span class="repl-input">(make-instance 'drakma:cookie
-                 :name "Foo"
+                 :name "Foo" 
                  :value "Bar"
                  :expires (+ (get-universal-time) 3600)
                  :domain ".weitz.de")</span>

--- a/drakma.asd
+++ b/drakma.asd
@@ -50,7 +50,7 @@
                (:file "cookies")
                (:file "encoding")
                (:file "request"))
-  :depends-on (:quri
+  :depends-on (:puri
                :cl-base64
                :chunga
                :flexi-streams

--- a/request.lisp
+++ b/request.lisp
@@ -231,10 +231,10 @@ headers of the chunked stream \(if any) as a second value."
                               (write-timeout 20 write-timeout-provided-p)
                               #+:openmcl
                               deadline
-                              &aux (unparsed-uri (if (stringp uri) (copy-seq uri) (quri:copy-uri uri))))
+                              &aux (unparsed-uri (if (stringp uri) (copy-seq uri) (puri:copy-uri uri))))
   "Sends a HTTP request to a web server and returns its reply.  URI
 is where the request is sent to, and it is either a string denoting a
-uniform resource identifier or a QURI:URI object.  The scheme of URI
+uniform resource identifier or a PURI:URI object.  The scheme of URI
 must be `http' or `https'.  The function returns SEVEN values - the
 body of the reply \(but see below), the status code as an integer, an
 alist of the headers sent by the server where for each element the car
@@ -480,12 +480,12 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
   (declare (ignore certificate key certificate-password verify max-depth ca-file ca-directory))
   (unless (member protocol '(:http/1.0 :http/1.1) :test #'eq)
     (parameter-error "Don't know how to handle protocol ~S." protocol))
-  (setq uri (cond ((quri:uri-p uri) (quri:copy-uri uri))
-                  (t (quri:parse-uri uri))))
+  (setq uri (cond ((puri:uri-p uri) (puri:copy-uri uri))
+                  (t (puri:parse-uri uri))))
   (unless (member method +known-methods+ :test #'eq)
     (parameter-error "Don't know how to handle method ~S." method))
-  (unless (member (quri:uri-scheme uri) '(:http :https) :test #'eq)
-    (parameter-error "Don't know how to handle scheme ~S." (quri:uri-scheme uri)))
+  (unless (member (puri:uri-scheme uri) '(:http :https) :test #'eq)
+    (parameter-error "Don't know how to handle scheme ~S." (puri:uri-scheme uri)))
   (when (and close keep-alive)
     (parameter-error "CLOSE and KEEP-ALIVE must not be both true."))
   (when (and form-data (not (member method '(:post :report) :test #'eq)))
@@ -504,7 +504,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
     (when (atom proxy)
       (setq proxy (list proxy 80))))
   ;; Ignore the proxy for whitelisted hosts.
-  (when (member (quri:uri-host uri) no-proxy-domains :test #'string=)
+  (when (member (puri:uri-host uri) no-proxy-domains :test #'string=)
     (setq proxy '()))
   ;; make sure we don't get :CRLF on Windows
   (let ((*default-eol-style* :lf)
@@ -531,18 +531,18 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (t
                (setq content (alist-to-url-encoded-string parameters external-format-out url-encoder)
                      content-type "application/x-www-form-urlencoded")))))
-    (let ((proxying-https-p (and proxy (not stream) (eq :https (quri:uri-scheme uri))))
+    (let ((proxying-https-p (and proxy (not stream) (eq :https (puri:uri-scheme uri))))
            http-stream raw-http-stream must-close done)
       (unwind-protect
           (progn
             (let ((host (or (and proxy (first proxy))
-                            (quri:uri-host uri)))
+                            (puri:uri-host uri)))
                   (port (cond (proxy (second proxy))
-                              ((quri:uri-port uri))
+                              ((puri:uri-port uri))
                               (t (default-port uri))))
                   (use-ssl (and (not proxying-https-p)
                                 (or force-ssl
-                                    (eq (quri:uri-scheme uri) :https)))))
+                                    (eq (puri:uri-scheme uri) :https)))))
               #+(and :lispworks5.0 :mswindows
                      (not :lw-does-not-have-write-timeout))
               (when use-ssl
@@ -613,9 +613,9 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 ;; set up a tunnel through the proxy server to the
                 ;; final destination
                 (write-http-line "CONNECT ~A:~:[443~;~:*~A~] HTTP/1.1"
-                                 (quri:uri-host uri) (quri:uri-port uri))
+                                 (puri:uri-host uri) (puri:uri-port uri))
                 (write-http-line "Host: ~A:~:[443~;~:*~A~]"
-                                 (quri:uri-host uri) (quri:uri-port uri))
+                                 (puri:uri-host uri) (puri:uri-port uri))
                 (write-http-line "")
                 (force-output http-stream)
                 ;; check we get a 200 response before proceeding
@@ -630,30 +630,33 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 (setq http-stream (wrap-stream (make-ssl-stream raw-http-stream))))
               (when-let (all-get-parameters
                          (and (not preserve-uri)
-                              (append (dissect-query (quri:uri-query uri))
+                              (append (dissect-query (puri:uri-query uri))
                                       (and (not parameters-used-p) parameters))))
-                (setf (quri:uri-query uri)
+                (setf (puri:uri-query uri)
                       (alist-to-url-encoded-string all-get-parameters external-format-out url-encoder)))
               (when (eq method :options*)
                 ;; special pseudo-method
                 (setf method :options
-                      (quri:uri-path uri) "*"
-                      (quri:uri-query uri) nil))
+                      (puri:uri-path uri) "*"
+                      (puri:uri-query uri) nil))
               (write-http-line "~A ~A ~A"
                                (string-upcase method)
                                (if (and preserve-uri
                                         (stringp unparsed-uri))
                                    (trivial-uri-path unparsed-uri)
-                                   (quri:render-uri (if (and proxy
+                                   (puri:render-uri (if (and proxy
                                                              (null stream)
                                                              (not proxying-https-p)
                                                              (not real-host))
                                                         uri
-                                                        (quri.uri:make-uri :path (quri:uri-path uri)
-                                                                           :query (quri:uri-query uri)))
+                                                        (make-instance 'puri:uri
+                                                                       :path (puri:uri-path uri)
+                                                                       :parsed-path (puri:uri-parsed-path uri)
+                                                                       :query (puri:uri-query uri)
+                                                                       :escaped t))
                                                     nil))
                                (string-upcase protocol))
-              (write-header "Host" "~A~@[:~A~]" (quri:uri-host uri) (non-default-port uri))
+              (write-header "Host" "~A~@[:~A~]" (puri:uri-host uri) (non-default-port uri))
               (when user-agent
                 (write-header "User-Agent" "~A" (user-agent-string user-agent)))
               (when basic-authorization
@@ -769,14 +772,14 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                  (when auto-referer
                                    (setq additional-headers (set-referer uri additional-headers)))
                                  (let* ((location (header-value :location headers))
-                                        (new-uri (quri:merge-uris location uri))
+                                        (new-uri (puri:merge-uris location uri))
                                         ;; can we re-use the stream?
-                                        (old-server-p (and (string= (quri:uri-host new-uri)
-                                                                    (quri:uri-host uri))
-                                                           (eql (quri:uri-port new-uri)
-                                                                (quri:uri-port uri))
-                                                           (eq (quri:uri-scheme new-uri)
-                                                               (quri:uri-scheme uri)))))
+                                        (old-server-p (and (string= (puri:uri-host new-uri)
+                                                                    (puri:uri-host uri))
+                                                           (eql (puri:uri-port new-uri)
+                                                                (puri:uri-port uri))
+                                                           (eq (puri:uri-scheme new-uri)
+                                                               (puri:uri-scheme uri)))))
                                    (unless old-server-p
                                      (setq must-close t
                                            want-stream nil))

--- a/util.lisp
+++ b/util.lisp
@@ -96,7 +96,18 @@ PREFIX whereby the elements are compared using TEST."
 (defun url-encode (string external-format)
   "Returns a URL-encoded version of the string STRING using the
 external format EXTERNAL-FORMAT."
-  (quri:url-encode string :encoding external-format :space-to-plus t))
+  (with-output-to-string (out)
+    (loop for octet across (string-to-octets (or string "")
+                                             :external-format external-format)
+          for char = (code-char octet)
+          do (cond ((or (char<= #\0 char #\9)
+                        (char<= #\a char #\z)
+                        (char<= #\A char #\Z)
+                        (find char "$-_.!*'()," :test #'char=))
+                     (write-char char out))
+                   ((char= char #\Space)
+                     (write-char #\+ out))
+                   (t (format out "%~2,'0x" (char-code char)))))))
 
 (defun alist-to-url-encoded-string (alist external-format url-encoder)
   "ALIST is supposed to be an alist of name/value pairs where both
@@ -116,17 +127,17 @@ value with a #\\= character.  If the value is NIL, no #\\= is used."
                       (funcall url-encoder value external-format)))))
 
 (defun default-port (uri)
-  "Returns the default port number for the \(QURI) URI URI.
+  "Returns the default port number for the \(PURI) URI URI.
 Works only with the http and https schemes."
-  (ecase (quri:uri-scheme uri)
+  (ecase (puri:uri-scheme uri)
     (:http 80)
     (:https 443)))
 
 (defun non-default-port (uri)
-  "If the \(QURI) URI specifies an explicit port number which is
+  "If the \(PURI) URI specifies an explicit port number which is
 different from the default port its scheme, this port number is
 returned, otherwise NIL."
-  (when-let (port (quri:uri-port uri))
+  (when-let (port (puri:uri-port uri))
     (when (/= port (default-port uri))
       port)))
 
@@ -255,7 +266,7 @@ which are not meant as separators."
         (string-length (length string))
         search-start
         result)
-    (tagbody
+    (tagbody     
      ;; at this point we know that COOKIE-START is the start of a new
      ;; cookie (at the start of the string or behind a comma)
      next-cookie
@@ -271,7 +282,7 @@ which are not meant as separators."
             (equals-pos (and comma-pos (position #\= string :start comma-pos)))
             ;; check that (except for whitespace) there's only a token
             ;; (the name of the next cookie) between #\, and #\=
-            (new-cookie-start-p (and equals-pos
+            (new-cookie-start-p (and equals-pos                                     
                                      (every 'token-char-p
                                             (trim-whitespace string
                                                              :start (1+ comma-pos)
@@ -327,7 +338,7 @@ which are not meant as separators."
   (error "SSL not supported. Remove :drakma-no-ssl from *features* to enable SSL"))
 
 (defun dissect-query (query-string)
-  "Accepts a query string as in QURI:URI-QUERY and returns a
+  "Accepts a query string as in PURI:URI-QUERY and returns a
 corresponding alist of name/value pairs."
   (when query-string
     (loop for parameter-pair in (cl-ppcre:split "&" query-string)


### PR DESCRIPTION
I need to pull back this change as it causes too many problems with existing software that either expect to be able to pass PURI:URI instances as arguments to HTTP-REQUEST, expect that PURI would be pulled as a dependency of DRAKMA or that want to operate on the PURI:URI object returned.  Sorry.