### PR TITLE
Support SNI with cl+ssl.

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -596,6 +596,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 (comm:attach-ssl http-stream :ssl-side :client)
                 #-:lispworks
                 (setq http-stream (make-ssl-stream http-stream
+                                                   :hostname host
                                                    :certificate certificate
                                                    :key key
                                                    :certificate-password certificate-password

--- a/util.lisp
+++ b/util.lisp
@@ -296,10 +296,11 @@ which are not meant as separators."
          (go next-cookie))))))
 
 #-:lispworks
-(defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory)
+(defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
+                                         hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream
 \(which will not be equal to HTTP-STREAM)."
-  (declare (ignorable http-stream certificate-password max-depth ca-directory))
+  (declare (ignorable http-stream certificate-password max-depth ca-directory hostname))
   (check-type verify (member nil :optional :required))
   (when (and certificate
              (not (probe-file certificate)))
@@ -330,6 +331,7 @@ which are not meant as separators."
       (warn ":verify, :max-depth, :ca-file and :ca-directory arguments not available on this platform"))
     (cl+ssl:make-ssl-client-stream
      (cl+ssl:stream-fd s)
+     :hostname hostname
      :close-callback (lambda () (close s))
      :certificate certificate
      :key key


### PR DESCRIPTION
Now that `cl+ssl` supports SNI, it would be nice if Drakma passed the `:hostname` argument so it can be used with SNI-enabled sites.