### PR TITLE
SSL verification for CL+SSL

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -57,7 +57,7 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :lispworks :allegro :mocl-ssl :drakma-no-ssl) :cl+ssl)
+               #-(or :allegro :drakma-no-ssl) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/drakma.asd
+++ b/drakma.asd
@@ -57,7 +57,7 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :allegro :drakma-no-ssl) :cl+ssl)
+               #-(or :lispworks :allegro :mocl-ssl :drakma-no-ssl) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/request.lisp
+++ b/request.lisp
@@ -531,7 +531,9 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (t
                (setq content (alist-to-url-encoded-string parameters external-format-out url-encoder)
                      content-type "application/x-www-form-urlencoded")))))
-    (let ((proxying-https-p (and proxy (not stream) (eq :https (puri:uri-scheme uri))))
+    (let ((proxying-https-p (and proxy (not stream)
+                                 (or force-ssl
+                                     (eq :https (puri:uri-scheme uri)))))
            http-stream raw-http-stream must-close done)
       (unwind-protect
           (progn
@@ -628,7 +630,16 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 #+:lispworks
                 (comm:attach-ssl raw-http-stream :ssl-side :client)
                 #-:lispworks
-                (setq http-stream (wrap-stream (make-ssl-stream raw-http-stream))))
+                (setq http-stream (wrap-stream
+                                   (make-ssl-stream raw-http-stream
+                                                    :hostname host
+                                                    :certificate certificate
+                                                    :key key
+                                                    :certificate-password certificate-password
+                                                    :verify verify
+                                                    :max-depth max-depth
+                                                    :ca-file ca-file
+                                                    :ca-directory ca-directory))))
               (when-let (all-get-parameters
                          (and (not preserve-uri)
                               (append (dissect-query (puri:uri-query uri))

--- a/request.lisp
+++ b/request.lisp
@@ -194,7 +194,7 @@ headers of the chunked stream \(if any) as a second value."
                               key
                               certificate-password
                               verify
-                              max-depth
+                              (max-depth 10)
                               ca-file
                               ca-directory
                               parameters

--- a/request.lisp
+++ b/request.lisp
@@ -281,8 +281,7 @@ CA-FILE and CA-DIRECTORY can be specified to set the certificate
 authority bundle file or directory to use for certificate validation.
 
 The CERTIFICATE, KEY, CERTIFICATE-PASSWORD, VERIFY, MAX-DEPTH, CA-FILE
-and CA-DIRECTORY parameters are ignored for non-SSL requests.  They
-are also ignored on LispWorks.
+and CA-DIRECTORY parameters are ignored for non-SSL requests.
 
 PARAMETERS is an alist of name/value pairs \(the car and the cdr each
 being a string) which denotes the parameters which are added to the

--- a/request.lisp
+++ b/request.lisp
@@ -476,8 +476,6 @@ decoded according to any encodings specified in the Content-Encoding
 header. The actual decoding is done by the DECODE-STREAM generic function,
 and you can implement new methods to support additional encodings.
 Any encodings in Transfer-Encoding, such as chunking, are always performed."
-  #+lispworks
-  (declare (ignore certificate key certificate-password verify max-depth ca-file ca-directory))
   (unless (member protocol '(:http/1.0 :http/1.1) :test #'eq)
     (parameter-error "Don't know how to handle protocol ~S." protocol))
   (setq uri (cond ((puri:uri-p uri) (puri:copy-uri uri))
@@ -594,9 +592,6 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (when (and use-ssl
                          ;; don't attach SSL to existing streams
                          (not stream))
-                #+:lispworks
-                (comm:attach-ssl http-stream :ssl-side :client)
-                #-:lispworks
                 (setq http-stream (make-ssl-stream http-stream
                                                    :hostname host
                                                    :certificate certificate
@@ -627,9 +622,6 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 ;; got a connection; we have to read a blank line,
                 ;; turn on SSL, and then we can transmit
                 (read-line* http-stream)
-                #+:lispworks
-                (comm:attach-ssl raw-http-stream :ssl-side :client)
-                #-:lispworks
                 (setq http-stream (wrap-stream
                                    (make-ssl-stream raw-http-stream
                                                     :hostname host

--- a/util.lisp
+++ b/util.lisp
@@ -295,6 +295,7 @@ which are not meant as separators."
          (setq cookie-start (1+ end-pos))
          (go next-cookie))))))
 
+#-:lispworks
 (defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
                                          hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream
@@ -319,7 +320,12 @@ which are not meant as separators."
                                  :max-depth max-depth
                                  :ca-file ca-file
                                  :ca-directory ca-directory)
-  #+(and (not :allegro) (not :drakma-no-ssl))
+  #+(and :mocl-ssl (not :drakma-no-ssl))
+  (progn
+    (when (or ca-file ca-directory)
+      (warn ":max-depth, :ca-file and :ca-directory arguments not available on this platform"))
+    (rt:start-ssl http-stream :verify verify))
+  #+(and (not :allegro) (not :mocl-ssl) (not :drakma-no-ssl))
   (let ((s http-stream)
         (ctx (cl+ssl:make-context :verify-depth max-depth
                                   :verify-mode (if (eql verify :required)

--- a/util.lisp
+++ b/util.lisp
@@ -295,7 +295,6 @@ which are not meant as separators."
          (setq cookie-start (1+ end-pos))
          (go next-cookie))))))
 
-#-:lispworks
 (defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
                                          hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream
@@ -320,12 +319,7 @@ which are not meant as separators."
                                  :max-depth max-depth
                                  :ca-file ca-file
                                  :ca-directory ca-directory)
-  #+(and :mocl-ssl (not :drakma-no-ssl))
-  (progn
-    (when (or ca-file ca-directory)
-      (warn ":max-depth, :ca-file and :ca-directory arguments not available on this platform"))
-    (rt:start-ssl http-stream :verify verify))
-  #+(and (not :allegro) (not :mocl-ssl) (not :drakma-no-ssl))
+  #+(and (not :allegro) (not :drakma-no-ssl))
   (let ((s http-stream)
         (ctx (cl+ssl:make-context :verify-depth max-depth
                                   :verify-mode (if (eql verify :required)


### PR DESCRIPTION
Added SSL verification (and other options like ca-path) for CL+SSL. Also fixed proxying for https.
Note that I've tested this only with CCL and SBCL on FreeBSD.