### PR TITLE
fixes https://github.com/edicl/drakma/issues/73

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -57,7 +57,7 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :lispworks :allegro :mocl-ssl :drakma-no-ssl) :cl+ssl)
+               #-(or :lispworks (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/util.lisp
+++ b/util.lisp
@@ -311,7 +311,7 @@ which are not meant as separators."
   (when (and ca-file
              (not (probe-file ca-file)))
     (error "ca file ~A not found" ca-file))
-  #+(and :allegro (not :drakma-no-ssl))
+  #+(and :allegro (not :allegro-cl-express) (not :drakma-no-ssl))
   (socket:make-ssl-client-stream http-stream
                                  :certificate certificate
                                  :key key
@@ -325,7 +325,7 @@ which are not meant as separators."
     (when (or ca-file ca-directory)
       (warn ":max-depth, :ca-file and :ca-directory arguments not available on this platform"))
     (rt:start-ssl http-stream :verify verify))
-  #+(and (not :allegro) (not :mocl-ssl) (not :drakma-no-ssl))
+  #+(and (or :allegro-cl-express (not :allegro)) (not :mocl-ssl) (not :drakma-no-ssl))
   (let ((s http-stream)
         (ctx (cl+ssl:make-context :verify-depth max-depth
                                   :verify-mode (if (eql verify :required)


### PR DESCRIPTION
Modified feature tests for Allegro because the free Allegro CL Express doesn't include SSL support. 

Tested with the call 

    (drakma:http-request "https://docs-examples.firebaseio.com/rest/quickstart/users.json") 

in Allegro CL Express 10.0 and Lispworks Personal Edition 6.1 on MacOS El Capitan.