### PR TITLE
Stream Buffer Size

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -43,6 +43,7 @@
            #:*header-stream*
            #:*ignore-unparseable-cookie-dates-p*
            #:*text-content-types*
+           #:*limited-array-size*
            #:cookie
            #:cookie-error
            #:cookie-error-cookie

--- a/request.lisp
+++ b/request.lisp
@@ -132,6 +132,18 @@ body using the boundary BOUNDARY."
   ;; details here: http://abcl.org/trac/ticket/377
   #-abcl
   (declare (stream stream))
+  #+(and ccl 32-bit-host)
+  (progn
+    (when (> buffer-size 16777215)
+      (setq buffer-size 16777215))
+    (let ((buffer (make-array buffer-size :element-type element-type))
+          (result ()))
+      (loop :for index = 0 :then (+ index pos)
+            :for pos = (read-sequence buffer stream :start 0 :end buffer-size)
+            :do (dotimes (i pos) (push (aref buffer i) result))
+            :while (= pos buffer-size))
+      (nreverse result)))
+  #-(and ccl 32-bit-host)
   "Helper function to read from stream into a buffer of element-type, which is returned."
   (let ((buffer (make-array buffer-size :element-type element-type))
         (result (make-array 0 :element-type element-type :adjustable t)))

--- a/request.lisp
+++ b/request.lisp
@@ -134,6 +134,10 @@ body using the boundary BOUNDARY."
   #-abcl
   (declare (stream stream))
   #+(and ccl 32-bit-host)
+  ;; In 32-bit Clozure-CL the maximum array size limit  
+  ;; is (expt 2 24) elements. 
+  ;; See: http://ccl.clozure.com/manual/chapter4.7.html
+  ;; Use a list as buffer instead 
   (progn
     (when (>= buffer-size array-total-size-limit)
       (setq buffer-size (- array-total-size-limit 1)))

--- a/request.lisp
+++ b/request.lisp
@@ -127,6 +127,7 @@ body using the boundary BOUNDARY."
       (crlf))))
 
 (defun %read-body (stream element-type &key (buffer-size +buffer-size+))
+  "Helper function to read from stream into a buffer of element-type, which is returned."
   ;; On ABCL, a flexi-stream is not a normal stream. This is caused by
   ;; a bug in ABCL which is supposedly quite difficult to fix. More
   ;; details here: http://abcl.org/trac/ticket/377
@@ -134,7 +135,7 @@ body using the boundary BOUNDARY."
   (declare (stream stream))
   #+(and ccl 32-bit-host)
   (progn
-    (when (> buffer-size (- array-total-size-limit 1))
+    (when (>= buffer-size array-total-size-limit)
       (setq buffer-size (- array-total-size-limit 1)))
     (let ((buffer (make-array buffer-size :element-type element-type))
           (result ()))
@@ -144,7 +145,6 @@ body using the boundary BOUNDARY."
             :while (= pos buffer-size))
       (nreverse result)))
   #-(and ccl 32-bit-host)
-  "Helper function to read from stream into a buffer of element-type, which is returned."
   (let ((buffer (make-array buffer-size :element-type element-type))
         (result (make-array 0 :element-type element-type :adjustable t)))
         (loop :for index = 0 :then (+ index pos)
@@ -478,7 +478,7 @@ time units.  If the server fails to respond until that time, a
 COMMUNICATION-DEADLINE-EXPIRED condition is signalled.  DEADLINE is
 only available on CCL 1.2 and later.
 
-BUFFER-SIZE is the size of the buffer used for reading from the 
+BUFFER-SIZE is the size of the buffer used for reading from the
 HTTP-stream and writing to it.
 
 If PRESERVE-URI is not NIL, the given URI will not be processed. This

--- a/request.lisp
+++ b/request.lisp
@@ -133,11 +133,10 @@ body using the boundary BOUNDARY."
   ;; details here: http://abcl.org/trac/ticket/377
   #-abcl
   (declare (stream stream))
-  #+(and ccl 32-bit-host)
-  ;; In 32-bit Clozure-CL the maximum array size limit  
-  ;; is (expt 2 24) elements. 
+  ;; In 32-bit Clozure-CL the maximum array size limit
+  ;; is (expt 2 24) elements.
   ;; See: http://ccl.clozure.com/manual/chapter4.7.html
-  ;; Use a list as buffer instead 
+  ;; Use a list as buffer
   (progn
     (when (>= buffer-size array-total-size-limit)
       (setq buffer-size (- array-total-size-limit 1)))
@@ -147,22 +146,13 @@ body using the boundary BOUNDARY."
             :for pos = (read-sequence buffer stream :start 0 :end buffer-size)
             :do (dotimes (i pos) (push (aref buffer i) result))
             :while (= pos buffer-size))
-      (nreverse result)))
-  #-(and ccl 32-bit-host)
-  (let ((buffer (make-array buffer-size :element-type element-type))
-        (result (make-array 0 :element-type element-type :adjustable t)))
-        (loop :for index = 0 :then (+ index pos)
-              :for pos = (read-sequence buffer stream :start 0 :end buffer-size)
-              :do (adjust-array result (+ index pos))
-                  (replace result buffer :start1 index :end2 pos)
-              :while (= pos buffer-size))
-        result))
+      (nreverse result))))
 
 (defun read-body (stream headers textp &key (decode-content t) (buffer-size +buffer-size+))
   "Reads the message body from the HTTP stream STREAM using the
 information contained in HEADERS \(as produced by HTTP-REQUEST).  If
 TEXTP is true, the body is assumed to be of content type `text' and
-will be returned as a string.  Otherwise an array of octets \(or NIL
+will be returned as a string.  Otherwise a sequence of octets \(or NIL
 for an empty body) is returned.  Returns the optional `trailer' HTTP
 headers of the chunked stream \(if any) as a second value."
   (let ((content-length (when-let (value (and (not (header-value :transfer-encoding headers)) ;; see RFC 2616, section 4.4, 3.
@@ -440,11 +430,11 @@ will try to return it as a Lisp string.  It'll first check if the
 `Content-Type' header denotes an encoding to be used, or otherwise it
 will use the EXTERNAL-FORMAT-IN argument.  The body is decoded using
 FLEXI-STREAMS.  If FLEXI-STREAMS doesn't know the external format, the
-body is returned as an array of octets.  If the body is empty, Drakma
+body is returned as a sequence of octets.  If the body is empty, Drakma
 will return NIL.
 
 If the message body doesn't have a text content type or if
-FORCE-BINARY is true, the body is always returned as an array of
+FORCE-BINARY is true, the body is always returned as a sequence of
 octets.
 
 If WANT-STREAM is true, the message body is NOT read and instead the

--- a/request.lisp
+++ b/request.lisp
@@ -134,8 +134,8 @@ body using the boundary BOUNDARY."
   (declare (stream stream))
   #+(and ccl 32-bit-host)
   (progn
-    (when (> buffer-size 16777215)
-      (setq buffer-size 16777215))
+    (when (> buffer-size (- array-total-size-limit 1))
+      (setq buffer-size (- array-total-size-limit 1)))
     (let ((buffer (make-array buffer-size :element-type element-type))
           (result ()))
       (loop :for index = 0 :then (+ index pos)

--- a/request.lisp
+++ b/request.lisp
@@ -137,16 +137,21 @@ body using the boundary BOUNDARY."
   ;; is (expt 2 24) elements.
   ;; See: http://ccl.clozure.com/manual/chapter4.7.html
   ;; Use a list as buffer
-  (progn
-    (when (>= buffer-size array-total-size-limit)
-      (setq buffer-size (- array-total-size-limit 1)))
-    (let ((buffer (make-array buffer-size :element-type element-type))
-          (result ()))
-      (loop :for index = 0 :then (+ index pos)
-            :for pos = (read-sequence buffer stream :start 0 :end buffer-size)
-            :do (dotimes (i pos) (push (aref buffer i) result))
-            :while (= pos buffer-size))
-      (nreverse result))))
+  (let ((result ()))
+    (loop with array-size = (if (>= buffer-size array-total-size-limit)
+                                (- array-total-size-limit 1)
+                                buffer-size)
+          with buffer = (make-array array-size :element-type element-type)
+          for index = 0 then (+ index pos)
+          for pos = (read-sequence buffer stream :start 0 :end array-size)
+          do (dotimes (i pos)
+               (push (aref buffer i) result))
+          while (= pos array-size))
+    (setq result
+          (nreverse result))
+    (if (subtypep element-type 'character)
+        (coerce result 'string)
+        result)))
 
 (defun read-body (stream headers textp &key (decode-content t) (buffer-size +buffer-size+))
   "Reads the message body from the HTTP stream STREAM using the

--- a/request.lisp
+++ b/request.lisp
@@ -126,6 +126,41 @@ body using the boundary BOUNDARY."
       (format stream "--~A--" boundary)
       (crlf))))
 
+(declaim (inline %read-body-into-list))
+(defun %read-body-into-list (stream element-type buffer-size)
+  "Helper function for cases where array-total-size-limit could be
+smaller than the number of elements that can be read from stream"
+  (let ((result ()))
+    (declare (type sequence result))
+    (loop with buffer = (make-array buffer-size :element-type element-type)
+          for index = 0 then (+ index pos)
+          for pos = (read-sequence buffer stream :start 0 :end buffer-size)
+          do (dotimes (i pos)
+               (push (aref buffer i) result))
+          while (= pos buffer-size))
+    (setq result
+          (nreverse result))
+    ;; element-type character -> return a string
+    (when (subtypep element-type 'character)
+      (if (>= (length result) array-total-size-limit)
+          (warn "Maximum possible string length exceeded! Returning a list of characters instead.")
+          (setq result
+                (coerce result 'string))))
+    result))
+
+(declaim (inline %read-body-into-array))
+(defun %read-body-into-array (stream element-type buffer-size)
+   "Helper function for cases where buffer-size does not exceed
+the array size limit"
+  (loop with buffer = (make-array buffer-size :element-type element-type)
+        with result = (make-array 0 :element-type element-type :adjustable t)
+        for index = 0 then (+ index pos)
+        for pos = (read-sequence buffer stream)
+        do (adjust-array result (+ index pos))
+           (replace result buffer :start1 index :end2 pos)
+        while (= pos buffer-size)
+        finally (return result)))
+
 (defun %read-body (stream element-type &key (buffer-size +buffer-size+))
   "Helper function to read from stream into a buffer of element-type, which is returned."
   ;; On ABCL, a flexi-stream is not a normal stream. This is caused by
@@ -133,25 +168,13 @@ body using the boundary BOUNDARY."
   ;; details here: http://abcl.org/trac/ticket/377
   #-abcl
   (declare (stream stream))
-  ;; In 32-bit Clozure-CL the maximum array size limit
-  ;; is (expt 2 24) elements.
-  ;; See: http://ccl.clozure.com/manual/chapter4.7.html
-  ;; Use a list as buffer
-  (let ((result ()))
-    (loop with array-size = (if (>= buffer-size array-total-size-limit)
-                                (- array-total-size-limit 1)
-                                buffer-size)
-          with buffer = (make-array array-size :element-type element-type)
-          for index = 0 then (+ index pos)
-          for pos = (read-sequence buffer stream :start 0 :end array-size)
-          do (dotimes (i pos)
-               (push (aref buffer i) result))
-          while (= pos array-size))
-    (setq result
-          (nreverse result))
-    (if (subtypep element-type 'character)
-        (coerce result 'string)
-        result)))
+  (if *limited-array-size*
+      ;; correctly deal with limited array size
+      (%read-body-into-list stream
+                            element-type
+                            (min (- array-total-size-limit 1) buffer-size))
+      ;; fast path for documents smaller than array-total-size-limit
+      (%read-body-into-array stream element-type buffer-size)))
 
 (defun read-body (stream headers textp &key (decode-content t) (buffer-size +buffer-size+))
   "Reads the message body from the HTTP stream STREAM using the

--- a/specials.lisp
+++ b/specials.lisp
@@ -128,6 +128,14 @@ Management Mechanism, section 4.3.3 Cookie Management:
     attribute values exactly \(string) match those of a pre-existing
     cookie, the new cookie supersedes the old.")
 
+(defvar *limited-array-size* nil
+  "Switch that enables the download of documents whose size exceeds
+array-total-size-limit in CL implementations. Defaults to NIL.
+
+In 32-bit Clozure-CL, for example, the maximum array size limit
+is (expt 2 24) elements. Lists have no such size limit.
+See: http://ccl.clozure.com/manual/chapter4.7.html")
+
 (defvar *text-content-types* '(("text" . nil))
   "A list of conses which are used by the default value of
 *BODY-FORMAT-FUNCTION* to decide whether a 'Content-Type' header

--- a/specials.lisp
+++ b/specials.lisp
@@ -71,7 +71,8 @@
   "A list of HTTP methods that should be changed to GET in case of redirect
 (see http://en.wikipedia.org/wiki/Post/Redirect/Get).")
 
-(defconstant +buffer-size+ 8192)
+(defconstant +buffer-size+ 8192
+  "The size of the buffer used for reading and writing to the HTTP-stream.")
 
 (defvar *drakma-default-external-format* ':latin-1
   "The default value for the external format keyword arguments of

--- a/test/drakma-test.lisp
+++ b/test/drakma-test.lisp
@@ -121,3 +121,15 @@
     (is (subtypep (stream-element-type stream) 'flexi-streams:octet))
     (let ((buffer (make-array 1 :element-type 'flexi-streams:octet)))
       (read-sequence buffer stream))))
+
+(test read-stream
+  (let ((drakma:*limited-array-size* nil))
+    (flexi-streams:with-input-from-sequence (str #(0 1 2 3))
+      (is (equalp (drakma::%read-body str 'flexi-streams:octet) #(0 1 2 3))))
+    (with-input-from-string (str "test-string")
+      (is (string-equal (drakma::%read-body str 'character) "test-string"))))
+  (let ((drakma:*limited-array-size* t))
+    (flexi-streams:with-input-from-sequence (str #(0 1 2 3))
+      (is (equalp (drakma::%read-body str 'flexi-streams:octet) '(0 1 2 3))))
+    (with-input-from-string (str "test-string")
+      (is (string-equal (drakma::%read-body str 'character) "test-string")))))


### PR DESCRIPTION
Workaround for the Clozure-CL maximum array size limit (array-total-size-limit) of (expt 2 24) elements

Introduced Buffer-Size argument to allow a dynamic adaption of the http-stream buffer size.
The small default stream buffer leads to high GC load for large downloads.