### PR TITLE
Support all the :VERIFY values - :OPTIONAL, :REQUIRED, NIL - for cl+ssl case.

### DIFF
--- a/test/drakma-test.lisp
+++ b/test/drakma-test.lisp
@@ -121,3 +121,34 @@
     (is (subtypep (stream-element-type stream) 'flexi-streams:octet))
     (let ((buffer (make-array 1 :element-type 'flexi-streams:octet)))
       (read-sequence buffer stream))))
+
+(test verify.wrong.host
+  (signals error
+    (drakma:http-request "https://wrong.host.badssl.com/" :verify :required))
+  (signals error
+    (drakma:http-request "https://wrong.host.badssl.com/" :verify :optional))
+  (finishes
+    (drakma:http-request "https://wrong.host.badssl.com//" :verify nil)))
+
+(test verify.expired
+  (signals error
+    (drakma:http-request "https://expired.badssl.com//" :verify :required))
+  (signals error
+    (drakma:http-request "https://expired.badssl.com/" :verify :optional))
+  (finishes
+    (drakma:http-request "https://expired.badssl.com/" :verify nil)))
+
+(test verify.self-signed
+  (signals error
+    (drakma:http-request "https://self-signed.badssl.com/" :verify :required)))
+
+(test verify.untrusted-root
+  (signals error
+    (drakma:http-request "https://untrusted-root.badssl.com/" :verify :required)))
+
+(test verify.null
+  (signals error
+    (drakma:http-request "https://null.badssl.com/" :verify :required))
+  (finishes
+    (drakma:http-request "https://null.badssl.com/" :verify :optional)))
+

--- a/util.lisp
+++ b/util.lisp
@@ -328,9 +328,8 @@ which are not meant as separators."
   #+(and (or :allegro-cl-express (not :allegro)) (not :mocl-ssl) (not :drakma-no-ssl))
   (let ((s http-stream)
         (ctx (cl+ssl:make-context :verify-depth max-depth
-                                  :verify-mode (if (eql verify :required)
-                                                   cl+ssl:+ssl-verify-peer+
-                                                   cl+ssl:+ssl-verify-none+)
+                                  :verify-mode cl+ssl:+ssl-verify-none+
+                                  :verify-callback nil
                                   :verify-location (or (and ca-file ca-directory
                                                             (list ca-file ca-directory))
                                                        ca-file ca-directory
@@ -338,6 +337,7 @@ which are not meant as separators."
     (cl+ssl:with-global-context (ctx)
       (cl+ssl:make-ssl-client-stream
        (cl+ssl:stream-fd s)
+       :verify verify
        :hostname hostname
        :close-callback (lambda ()
                          (close s)


### PR DESCRIPTION
Currently, only NIL and  :REQUIRED are supported.

To implement the full support cl+ssl now provides new API: `cl+ssl:make-ssl-client-stream` now has a `:verify` parameter with the same semantics as Drakma, but `:required` is the default.

(BTW, due to cl+ssl now verifying by default, without passing this parameter Drakma's default behavior will change too when new OpenSSL is used - it will behave as if `:verify :required` is specified).

Tests provided using bad-ssl.com to check how verification parameters are implemented.

BTW, new cl+ssl also verifies hostname, so hostname verification comes to drakma with new cl+ssl.