### PR TITLE
Fix the hostname passed to make-ssl-stream when proxy is in use

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -598,7 +598,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 (comm:attach-ssl http-stream :ssl-side :client)
                 #-:lispworks
                 (setq http-stream (make-ssl-stream http-stream
-                                                   :hostname host
+                                                   :hostname (puri:uri-host uri)
                                                    :certificate certificate
                                                    :key key
                                                    :certificate-password certificate-password
@@ -632,7 +632,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 #-:lispworks
                 (setq http-stream (wrap-stream
                                    (make-ssl-stream raw-http-stream
-                                                    :hostname host
+                                                    :hostname (puri:uri-host uri)
                                                     :certificate certificate
                                                     :key key
                                                     :certificate-password certificate-password


### PR DESCRIPTION
Fix the hostname passed to make-ssl-stream when proxy is in use.
    
Pass the hostname of our target server instead of the proxy host -
make-ssl-stream uses the hostname for server name indication and
for hostname verification; therefore it wants the target host, not the proxy.

The following use-case demonstrates the problem on the current drakma and is fixed by this PR.
Here we tell cl+ssl to verify certificate against the hostname 200.162.142.178 while we should tell google.com instead.

```common-lisp
    (drakma:http-request "https://google.com/"
                         ;; some random proxy from the Internet
                         :proxy '("200.162.142.178" 3128)
                         :verify :required)
````
```
Error #<CL+SSL::UNABLE-TO-MATCH-ALTNAMES #x302001E3E0CD>
   [Condition of type CL+SSL::UNABLE-TO-MATCH-ALTNAMES]

Restarts:
 0: [RETRY] Retry SLIME interactive evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT-BREAK] Reset this thread
 3: [ABORT] Kill this thread

Backtrace:
  0: (CL+SSL::MAYBE-CHECK-SUBJECT-CN ("*.google.com" "*.android.com" "*.appengine.google.com" "*.cloud.google.com" "*.db833953.google.cn" "*.g.co" ...) #<A Foreign Pointer #x7F6498688010> "200.162.142.178"..
  1: (CL+SSL::MAYBE-VERIFY-CLIENT-STREAM #<SSL-STREAM for 4> :REQUIRED "200.162.142.178")
  2: (CL+SSL:MAKE-SSL-CLIENT-STREAM 4 :CERTIFICATE NIL :KEY NIL :PASSWORD NIL :METHOD CL+SSL::SSL-V23-METHOD :EXTERNAL-FORMAT NIL :CLOSE-CALLBACK #<COMPILED-LEXICAL-CLOSURE (:INTERNAL ..) :UNWRAP-STREAM-P ..
  3: (CL+SSL::CALL-WITH-GLOBAL-CONTEXT #<A Foreign Pointer #x7F649825B9A0> NIL #<COMPILED-LEXICAL-CLOSURE (:INTERNAL DRAKMA::MAKE-SSL-STREAM) #x302001E0A91F>)
  4: (DRAKMA:HTTP-REQUEST #<URI https://google.com/> :PROXY ("200.162.142.178" 3128) :VERIFY :REQUIRED)
  5: (CCL::CALL-CHECK-REGS DRAKMA:HTTP-REQUEST "https://google.com/" :PROXY ("200.162.142.178" 3128) :VERIFY :REQUIRED)
  6: (CCL::CHEAP-EVAL (DRAKMA:HTTP-REQUEST "https://google.com/" :PROXY '("200.162.142.178" 3128) :VERIFY ...))
  7: ((:INTERNAL SWANK:INTERACTIVE-EVAL))
  8: ((:INTERNAL SWANK::SPAWN-WORKER-THREAD))
  9: (CCL::RUN-PROCESS-INITIAL-FORM #<PROCESS worker(121) [Active] #x302001DCD25D> (#<COMPILED-LEXICAL-CLOSURE (:INTERNAL CCL::%PROCESS-RUN-FUNCTION) #x302001DCCFCF>))
 10: ((:INTERNAL (CCL::%PROCESS-PRESET-INTERNAL (PROCESS))) #<PROCESS worker(121) [Active] #x302001DCD25D> (#<COMPILED-LEXICAL-CLOSURE (:INTERNAL CCL::%PROCESS-RUN-FUNCTION) #x302001DCCFCF>))
 11: ((:INTERNAL CCL::THREAD-MAKE-STARTUP-FUNCTION))
```

I'm not adding the above example to the unit tests, because not sure we should rely onto random proxy from Internet. An alternative would be to implement a CONNECT proxy using Hunchentoot and Drakma, but that will take more significant work.