### PR TITLE
set the license and author fields of the asdf systems

### DIFF
--- a/drakma-test.asd
+++ b/drakma-test.asd
@@ -28,6 +28,8 @@
 
 (defsystem :drakma-test
   :description "Test suite for drakma"
+  :author "Dr. Edi Weitz"
+  :license "BSD"
   :serial t
   :version "0.1"
   :depends-on (:drakma :fiveam)

--- a/drakma.asd
+++ b/drakma.asd
@@ -40,6 +40,8 @@
 
 (defsystem :drakma
   :description "Full-featured http/https client based on usocket"
+  :author "Dr. Edi Weitz"
+  :license "BSD"
   :serial t
   :version "2.0.7"
   :components ((:file "packages")


### PR DESCRIPTION
According to the origin Drakma website, it is distributed under a BSD license
as it is for other software from Edi Weitz. Having the author and license
fields set (this is already the case for other libs such as cl-ppcre) is
always useful for information purposes.