### PR TITLE
Remove Authorization: header on redirect.

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -834,7 +834,8 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                                 :redirect (cond ((integerp redirect) (1- redirect))
                                                                 (t redirect))
                                                 :stream (and re-use-stream http-stream)
-                                                :additional-headers additional-headers
+                                                :additional-headers (remove "Authorization" additional-headers
+                                                                            :test 'string-equal :key 'car)
                                                 :parameters parameters
                                                 :preserve-uri t
                                                 :form-data (if (eq method :get)


### PR DESCRIPTION
Most clients strip the Authorization header on redirects, for security reasons. 

There is a recent IETF draft concerning redirects and authorization (https://tools.ietf.org/html/draft-williams-http-accept-auth-and-redirect-00) that should probably be included in future work on Drakma.