### PR TITLE
Fix `:real-host` support for HTTPS connections

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -538,7 +538,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (t
                (setq content (alist-to-url-encoded-string parameters external-format-out url-encoder)
                      content-type "application/x-www-form-urlencoded")))))
-    (let ((proxying-https-p (and proxy (not stream)
+    (let ((proxying-https-p (and proxy (not stream) (not real-host)
                                  (or force-ssl
                                      (eq :https (puri:uri-scheme uri)))))
            http-stream raw-http-stream must-close done)
@@ -546,7 +546,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
           (progn
             (let ((host (or (and proxy (first proxy))
                             (puri:uri-host uri)))
-                  (port (cond (proxy (second proxy))
+                  (port (cond ((and proxy (not real-host)) (second proxy))
                               ((puri:uri-port uri))
                               (t (default-port uri))))
                   (use-ssl (and (not proxying-https-p)


### PR DESCRIPTION
The `:real-host` feature is broken for HTTPS.  Evaluating:

    (drakma:http-request "https://github.com/404" :real-host "192.30.255.112" :redirect nil)

Produces:

    Unable to establish HTTPS tunnel through proxy.
       [Condition of type SIMPLE-ERROR]

Specifying the port also doesn’t work, but in a different way:

    (drakma:http-request "https://github.com/404" :real-host '("192.30.255.112" 443) :redirect nil)

    No status line - probably network error.
       [Condition of type DRAKMA::DRAKMA-SIMPLE-ERROR]

There are two bugs.

`proxying-https-p` is truthy when `real-host` is specified, because [`real-host` is copied to `proxy`](https://github.com/edicl/drakma/blob/e69f8e0d98af4d2c31e59006c9bbe7a2649ffb8b/request.lisp#L507-L508). This causes Drakma [issue a `CONNECT` verb](https://github.com/edicl/drakma/blob/e69f8e0d98af4d2c31e59006c9bbe7a2649ffb8b/request.lisp#L630-L631) the remote server doesn’t honor.

The fix for the first case is to inhibit setting `proxying-https-p` if `real-host` is specified.

However, this still breaks in the case where the `real-host` doesn’t include a port, because [the proxy port is always set to 80 when omitted](https://github.com/edicl/drakma/blob/e69f8e0d98af4d2c31e59006c9bbe7a2649ffb8b/request.lisp#L511-L512), and it’s already been set from `real-host`.

The second fix is to ignore `proxy` and take `port` from the URI when `real-host` is specified.