### PR TITLE
Remove test for server with null list of ciphers (https://null.badssl.com/) - newer version reject such connections without regard to cert verification options

### DIFF
--- a/test/drakma-test.lisp
+++ b/test/drakma-test.lisp
@@ -145,10 +145,3 @@
 (test verify.untrusted-root
   (signals error
     (drakma:http-request "https://untrusted-root.badssl.com/" :verify :required)))
-
-(test verify.null
-  (signals error
-    (drakma:http-request "https://null.badssl.com/" :verify :required))
-  (finishes
-    (drakma:http-request "https://null.badssl.com/" :verify :optional)))
-


### PR DESCRIPTION
This test fails on all implementations when up to date OpenSSL is used.
https://common-lisp.net/project/cl-test-grid/library/drakma.html
