### PR TITLE
Write header Proxy-Authorization before read-status-line to avoid HTTP status code 407

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -634,6 +634,12 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                  (puri:uri-host uri)
                                  (puri:uri-is-ip6 uri)
                                  (puri:uri-port uri))
+                (when (and proxy proxy-basic-authorization)
+                  (write-header "Proxy-Authorization" "Basic ~A"
+                                (base64:string-to-base64-string
+                                 (format nil "~A:~A"
+                                         (first proxy-basic-authorization)
+                                         (second proxy-basic-authorization)))))
                 (write-http-line "")
                 (force-output http-stream)
                 ;; check we get a 200 response before proceeding
@@ -702,7 +708,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                (format nil "~A:~A"
                                        (first basic-authorization)
                                        (second basic-authorization)))))
-              (when (and proxy proxy-basic-authorization)
+              (when (and proxy proxy-basic-authorization (not proxying-https-p))
                 (write-header "Proxy-Authorization" "Basic ~A"
                               (base64:string-to-base64-string
                                (format nil "~A:~A"


### PR DESCRIPTION
Tested with [Squid](http://www.squid-cache.org/)

Squid config example:

```conf
acl localnet src 10.0.0.0/8     # RFC1918 possible internal network
acl localnet src 172.16.0.0/12  # RFC1918 possible internal network
acl localnet src 192.168.0.0/16 # RFC1918 possible internal network
acl localnet src fc00::/7       # RFC 4193 local private network range
acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines

acl SSL_ports port 443
acl Safe_ports port 80          # http
acl Safe_ports port 21          # ftp
acl Safe_ports port 443         # https
acl Safe_ports port 70          # gopher
acl Safe_ports port 210         # wais
acl Safe_ports port 1025-65535  # unregistered ports
acl Safe_ports port 280         # http-mgmt
acl Safe_ports port 488         # gss-http
acl Safe_ports port 591         # filemaker
acl Safe_ports port 777         # multiling http
acl CONNECT method CONNECT

http_access deny !Safe_ports

http_access deny CONNECT !SSL_ports

http_access allow localhost manager
http_access deny manager
http_access allow localnet
http_access allow localhost

# Auth config
auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
auth_param basic children 5
auth_param basic realm Squid Basic Authentication
auth_param basic credentialsttl 2 hours
acl auth_users proxy_auth REQUIRED
http_access allow auth_users

# And finally deny all other access to this proxy
http_access deny all

http_port 3128

coredump_dir /var/spool/squid

refresh_pattern ^ftp:           1440    20%     10080
refresh_pattern ^gopher:        1440    0%      1440
refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
refresh_pattern .               0       20%     4320

cache deny all
```

add auth user:password line to file `/etc/squid/passwd` with command:

```shell
htpasswd -c /etc/squid/passwd username
```

test with drakma:

```lisp
;; test proxying-https-p condition
(drakma:http-request "https://www.example.com/"
                     :proxy '("127.0.0.1" 3128)
                     :proxy-basic-authorization '("username" "password"))

;; test NOT proxying-https-p condition
(drakma:http-request "http://www.example.com/"
                     :proxy '("127.0.0.1" 3128)
                     :proxy-basic-authorization '("username" "password"))
```

compared `curl` command:

```shell
curl -v -x http://username:password@:127.0.0.1:3128 http://www.example.com
curl -v -x http://username:password@:127.0.0.1:3128 https://www.example.com
```