### PR TITLE
LispWorks: Fix SSL verification

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -133,21 +133,19 @@ body using the boundary BOUNDARY."
   "Wrap COMM:ATTACH-SSL to create a version that can understand the
 VERIFY argument to enable certification verification. By default
 COMM:ATTACH-SSL does not verify certificates, at least on LispWorks 7."
-  (apply #'comm:attach-ssl stream
-           :ssl-configure-callback (lambda (ssl)
-                                     (comm:set-verification-mode
-                                      ssl :client
-                                      (case verify
-                                        (:required
-                                         :always)
-                                        (:optional
-                                         ;; There's no obvious equivalent to this on LispWorks, so
-                                         ;; we'll treat it the same as :required
-                                         :always)
-                                        (t
-                                         :never))
-                                      nil))
-           args))
+  (flet ((callback (ssl)
+           (comm:set-verification-mode ssl :client
+            (case verify
+              (:required :always)
+              (:optional
+               ;; There's no obvious equivalent to this on LispWorks, so
+               ;; we'll treat it the same as :required
+               :always)
+              (t :never))
+            nil)))
+   (apply #'comm:attach-ssl stream
+            :ssl-configure-callback #'callback
+            args)))
 
 (defun %read-body (stream element-type)
   ;; On ABCL, a flexi-stream is not a normal stream. This is caused by

--- a/request.lisp
+++ b/request.lisp
@@ -602,12 +602,15 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                          ;; don't attach SSL to existing streams
                          (not stream))
                 #+:lispworks
-                (comm:attach-ssl http-stream
-                                 :ssl-side :client
-                                 #-(or lispworks4 lispworks5 lispworks6)
-                                 :tlsext-host-name
-                                 #-(or lispworks4 lispworks5 lispworks6)
-                                 (puri:uri-host uri))
+                (let ((ctx (comm:make-ssl-ctx :ssl-side :client)))
+                  (comm:set-verification-mode ctx :client :always nil)
+                  (comm:attach-ssl http-stream
+                                   :ssl-ctx ctx
+                                   :ssl-side :client
+                                   #-(or lispworks4 lispworks5 lispworks6)
+                                   :tlsext-host-name
+                                   #-(or lispworks4 lispworks5 lispworks6)
+                                   (puri:uri-host uri)))
                 #-:lispworks
                 (setq http-stream (make-ssl-stream http-stream
                                                    :hostname (puri:uri-host uri)
@@ -643,12 +646,15 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 ;; turn on SSL, and then we can transmit
                 (read-line* http-stream)
                 #+:lispworks
-                (comm:attach-ssl raw-http-stream
-                                 :ssl-side :client
-                                 #-(or lispworks4 lispworks5 lispworks6)
-                                 :tlsext-host-name
-                                 #-(or lispworks4 lispworks5 lispworks6)
-                                 (puri:uri-host uri))
+                (let ((ctx (comm:make-ssl-ctx :ssl-side :client)))
+                  (comm:set-verification-mode ctx :client :always nil)
+                  (comm:attach-ssl raw-http-stream
+                                   :ssl-ctx ctx
+                                   :ssl-side :client
+                                   #-(or lispworks4 lispworks5 lispworks6)
+                                             :tlsext-host-name
+                                             #-(or lispworks4 lispworks5 lispworks6)
+                                             (puri:uri-host uri)))
                 #-:lispworks
                 (setq http-stream (wrap-stream
                                    (make-ssl-stream raw-http-stream


### PR DESCRIPTION
By default COMM:ATTACH-SSL doesn't doesn't do certificate verification, there needs to be an extra step to configure the SSL object, which is what this pull request does. Tests are passing now (it was failing earlier)

Communication from Martin Simmons from Lispworks when I checked this with him:

```
Hi Arnold,

LispWorks doesn't verify the certificate by default.  You need to use
comm:set-verification-mode to make it do this (see the example below).

Note that it can also be used inside the configuration callbacks that
can be passed to comm::open-tcp-stream, and also can be used on each
comm:ssl-pointer rather than on the comm:ssl-ctx-pointer.

The point of using the callbacks is to avoid the need to explicitly
create the ssl-ctx before calling comm:open-tcp-stream.


-------------------------------
(defvar *my-verifying-ctx* nil)
;;; initialize-verifying-ctx is assumed to be called once at run time during
;;; initialization of the application. 
(defun initialize-verifying-ctx ()
   (let ((ctx (comm:make-ssl-ctx ::ssl-side :client))) 
     (comm:set-verification-mode ctx :client :always nil) 
     ;; ... other configuration
     (setq *my-verifying-ctx* ctx)))
---------------------------


CL-USER 3 > (initialize-verifying-ctx)
#<SSL-CTX-POINTER = #x100223DF0 {CLIENT}>

CL-USER 4 > (comm:open-tcp-stream "google.com" 443 :ssl-ctx *my-verifying-ctx*)
#<COMM:SOCKET-STREAM 402001C02B>

CL-USER 5 > (comm:open-tcp-stream "self-signed.badssl.com" 443 :ssl-ctx *my-verifying-ctx*)

Error: SSL failure in #<COMM:SOCKET-STREAM 402001EEFB>: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
  1 (abort) Return to level 0.
  2 Restart top-level loop.

Type :b for backtrace or :c <option number> to proceed.
Type :bug-form "<subject>" for a bug report template or :? for other options.
```