### PR TITLE
Use cl+ssl library instead of "comm" module on lispworks 7.0 or before.

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -59,7 +59,7 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :lispworks (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
+               #-(or :lispworks7.1 (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/util.lisp
+++ b/util.lisp
@@ -295,7 +295,7 @@ which are not meant as separators."
          (setq cookie-start (1+ end-pos))
          (go next-cookie))))))
 
-#-:lispworks
+#-:lispworks7.1
 (defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
                                          hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream


### PR DESCRIPTION
LispWorks' "comm" module works fine on its version 7.1 (or later?).
So, We should use third party "cl+ssl" library instead of "comm" module on lispworks 7.0 or before.

Thank you.