### PR TITLE
Ensured the TLS context memory is released even if an error occurred.

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -344,7 +344,7 @@ which are not meant as separators."
                (cl+ssl:stream-fd s)
                :verify verify
                :hostname hostname
-               :close-callback #'cleanup-callback
+               :close-callback (lambda () (cleanup-callback s ctx))
                :certificate certificate
                :key key
                :password certificate-password))

--- a/util.lisp
+++ b/util.lisp
@@ -266,7 +266,7 @@ which are not meant as separators."
         (string-length (length string))
         search-start
         result)
-    (tagbody     
+    (tagbody
      ;; at this point we know that COOKIE-START is the start of a new
      ;; cookie (at the start of the string or behind a comma)
      next-cookie
@@ -282,7 +282,7 @@ which are not meant as separators."
             (equals-pos (and comma-pos (position #\= string :start comma-pos)))
             ;; check that (except for whitespace) there's only a token
             ;; (the name of the next cookie) between #\, and #\=
-            (new-cookie-start-p (and equals-pos                                     
+            (new-cookie-start-p (and equals-pos
                                      (every 'token-char-p
                                             (trim-whitespace string
                                                              :start (1+ comma-pos)
@@ -334,14 +334,12 @@ which are not meant as separators."
                                                             (list ca-file ca-directory))
                                                        ca-file ca-directory
                                                        :default))))
-    (cl+ssl:with-global-context (ctx)
+    (cl+ssl:with-global-context (ctx :auto-free-p t)
       (cl+ssl:make-ssl-client-stream
        (cl+ssl:stream-fd s)
        :verify verify
        :hostname hostname
-       :close-callback (lambda ()
-                         (close s)
-                         (cl+ssl:ssl-ctx-free ctx))
+       :close-callback (lambda () (close s))
        :certificate certificate
        :key key
        :password certificate-password)))

--- a/util.lisp
+++ b/util.lisp
@@ -334,23 +334,15 @@ which are not meant as separators."
                                                             (list ca-file ca-directory))
                                                        ca-file ca-directory
                                                        :default))))
-    (flet ((cleanup-callback (stream ssl-context)
-             (close stream)
-             (cl+ssl:ssl-ctx-free ssl-context)))
-      (cl+ssl:with-global-context (ctx)
-        (handler-case
-            (progn
-              (cl+ssl:make-ssl-client-stream
-               (cl+ssl:stream-fd s)
-               :verify verify
-               :hostname hostname
-               :close-callback (lambda () (cleanup-callback s ctx))
-               :certificate certificate
-               :key key
-               :password certificate-password))
-          (error (e)
-            (cleanup-callback s ctx)
-            (error e))))))
+    (cl+ssl:with-global-context (ctx :auto-free-p t)
+      (cl+ssl:make-ssl-client-stream
+       (cl+ssl:stream-fd s)
+       :verify verify
+       :hostname hostname
+       :close-callback (lambda () (close s))
+       :certificate certificate
+       :key key
+       :password certificate-password)))
   #+:drakma-no-ssl
   (error "SSL not supported. Remove :drakma-no-ssl from *features* to enable SSL"))
 


### PR DESCRIPTION
This patch try to mitigate the problem shown in issue #118 

I am still puzzled if `:close-callback` is useful at all so I am looking forward for reviews and suggestions!

Bye!
C.