### PR TITLE
Pass the socket stream instead of file descriptor to cl+ssl:make-ssl-client-stream

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -336,10 +336,9 @@ which are not meant as separators."
                                                        :default))))
     (cl+ssl:with-global-context (ctx :auto-free-p t)
       (cl+ssl:make-ssl-client-stream
-       (cl+ssl:stream-fd s)
+       s
        :verify verify
        :hostname hostname
-       :close-callback (lambda () (close s))
        :certificate certificate
        :key key
        :password certificate-password)))


### PR DESCRIPTION
This allows cl+ssl users to choose between SocketBIO and LispBIO by binding `cl+ssl:*default-unwrap-stream-p*`, and removes the need for `:close-callback` - when stream is passed tp cl+ssl, it automatically closes this underlying stream when cl+ssl stream is closed.