### PR TITLE
Patches for Lispworks 8.

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -59,7 +59,8 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :lispworks7.1 (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
+               #-(or :lispworks7.1 :lispworks8 (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl
+                     ) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/request.lisp
+++ b/request.lisp
@@ -160,7 +160,7 @@ headers of the chunked stream \(if any) as a second value."
                                               (header-value :content-length headers)))
                           (parse-integer value)))
         (element-type (if textp
-                        #+:lispworks7.1 'lw:simple-char #-:lispworks7.1 'character
+                        #+(or :lispworks7.1 :lispworks8) 'lw:simple-char #-(or :lispworks7.1 :lispworks8) 'character
                         'octet)))
     (values (cond ((eql content-length 0) nil)
                   (content-length
@@ -233,8 +233,8 @@ headers of the chunked stream \(if any) as a second value."
                               decode-content ; default to nil for backwards compatibility
                               #+(or abcl clisp lispworks mcl openmcl sbcl)
                               (connection-timeout 20)
-                              #+:lispworks7.1 (read-timeout 20)
-                              #+(and :lispworks7.1 (not :lw-does-not-have-write-timeout))
+                              #+(or :lispworks7.1 :lispworks8) (read-timeout 20)
+                              #+(and (or :lispworks7.1 :lispworks8) (not :lw-does-not-have-write-timeout))
                               (write-timeout 20 write-timeout-provided-p)
                               #+:openmcl
                               deadline
@@ -483,7 +483,7 @@ decoded according to any encodings specified in the Content-Encoding
 header. The actual decoding is done by the DECODE-STREAM generic function,
 and you can implement new methods to support additional encodings.
 Any encodings in Transfer-Encoding, such as chunking, are always performed."
-  #+lispworks7.1
+  #+ (or :lispworks7.1 :lispworks8)
   (declare (ignore certificate key certificate-password verify max-depth ca-file ca-directory))
   (unless (member protocol '(:http/1.0 :http/1.1) :test #'eq)
     (parameter-error "Don't know how to handle protocol ~S." protocol))
@@ -559,7 +559,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                   (drakma-warn "Disabling WRITE-TIMEOUT because it doesn't mix well with SSL."))
                 (setq write-timeout nil))
               (setq http-stream (or stream
-                                    #+:lispworks7.1
+                                    #+(or :lispworks7.1 :lispworks8)
                                     (comm:open-tcp-stream host port
                                                           :element-type 'octet
                                                           :timeout connection-timeout
@@ -569,7 +569,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                                           #-:lw-does-not-have-write-timeout
                                                           write-timeout
                                                           :errorp t)
-                                    #-:lispworks7.1
+                                    #-(or :lispworks7.1 :lispworks8)
                                     (usocket:socket-stream
                                      (usocket:socket-connect host port
                                                              :element-type 'octet
@@ -601,14 +601,14 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (when (and use-ssl
                          ;; don't attach SSL to existing streams
                          (not stream))
-                #+:lispworks7.1
+                #+(or :lispworks7.1 :lispworks8)
                 (comm:attach-ssl http-stream
                                  :ssl-side :client
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  :tlsext-host-name
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  (puri:uri-host uri))
-                #-:lispworks7.1
+                #-(or :lispworks7.1 :lispworks8)
                 (setq http-stream (make-ssl-stream http-stream
                                                    :hostname (puri:uri-host uri)
                                                    :certificate certificate
@@ -642,14 +642,14 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 ;; got a connection; we have to read a blank line,
                 ;; turn on SSL, and then we can transmit
                 (read-line* http-stream)
-                #+:lispworks7.1
+                #+(or :lispworks7.1 :lispworks8)
                 (comm:attach-ssl raw-http-stream
                                  :ssl-side :client
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  :tlsext-host-name
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  (puri:uri-host uri))
-                #-:lispworks7.1
+                #+(or :lispworks7.1 :lispworks8)
                 (setq http-stream (wrap-stream
                                    (make-ssl-stream raw-http-stream
                                                     :hostname (puri:uri-host uri)

--- a/util.lisp
+++ b/util.lisp
@@ -295,12 +295,13 @@ which are not meant as separators."
          (setq cookie-start (1+ end-pos))
          (go next-cookie))))))
 
-#-:lispworks7.1
+#-(or :lispworks7.1 :lispworks8)
 (defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
                                          hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream
 \(which will not be equal to HTTP-STREAM)."
-  (declare (ignorable http-stream certificate-password max-depth ca-directory hostname))
+  (declare (ignorable http-stream certificate-password max-depth ca-directory hostname)
+           (optimize (debug 3) (speed 0)))
   (check-type verify (member nil :optional :required))
   (when (and certificate
              (not (probe-file certificate)))


### PR DESCRIPTION
Unfortunately, it appears that LW hasn't defined a :lispworks8+
feature as of now, so we'll have to do this again when Lispworks 9
comes out.