### PR TITLE
fix up drakma for LispWorks 8.0

### DIFF
--- a/drakma.asd
+++ b/drakma.asd
@@ -59,7 +59,7 @@
                :cl-ppcre
                #-:drakma-no-chipz :chipz
                #-:lispworks :usocket
-               #-(or :lispworks7.1 (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
+               #-(or (and :lispworks (not :lispworks7+)) (and :allegro (not :allegro-cl-express)) :mocl-ssl :drakma-no-ssl) :cl+ssl)
   :perform (test-op (o s)
                     (asdf:load-system :drakma-test)
                     (asdf:perform 'asdf:test-op :drakma-test)))

--- a/request.lisp
+++ b/request.lisp
@@ -160,7 +160,7 @@ headers of the chunked stream \(if any) as a second value."
                                               (header-value :content-length headers)))
                           (parse-integer value)))
         (element-type (if textp
-                        #+:lispworks7.1 'lw:simple-char #-:lispworks7.1 'character
+                        #+:lispworks7+ 'lw:simple-char #-:lispworks7+ 'character
                         'octet)))
     (values (cond ((eql content-length 0) nil)
                   (content-length
@@ -239,8 +239,8 @@ headers of the chunked stream \(if any) as a second value."
                               decode-content ; default to nil for backwards compatibility
                               #+(or abcl clisp lispworks mcl openmcl sbcl)
                               (connection-timeout 20)
-                              #+:lispworks7.1 (read-timeout 20)
-                              #+(and :lispworks7.1 (not :lw-does-not-have-write-timeout))
+                              #+:lispworks7+ (read-timeout 20)
+                              #+(and :lispworks7+ (not :lw-does-not-have-write-timeout))
                               (write-timeout 20 write-timeout-provided-p)
                               #+:openmcl
                               deadline
@@ -489,7 +489,7 @@ decoded according to any encodings specified in the Content-Encoding
 header. The actual decoding is done by the DECODE-STREAM generic function,
 and you can implement new methods to support additional encodings.
 Any encodings in Transfer-Encoding, such as chunking, are always performed."
-  #+lispworks7.1
+  #+lispworks7+
   (declare (ignore certificate key certificate-password verify max-depth ca-file ca-directory))
   (unless (member protocol '(:http/1.0 :http/1.1) :test #'eq)
     (parameter-error "Don't know how to handle protocol ~S." protocol))
@@ -565,7 +565,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                   (drakma-warn "Disabling WRITE-TIMEOUT because it doesn't mix well with SSL."))
                 (setq write-timeout nil))
               (setq http-stream (or stream
-                                    #+:lispworks7.1
+                                    #+:lispworks7+
                                     (comm:open-tcp-stream host port
                                                           :element-type 'octet
                                                           :timeout connection-timeout
@@ -575,7 +575,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                                                           #-:lw-does-not-have-write-timeout
                                                           write-timeout
                                                           :errorp t)
-                                    #-:lispworks7.1
+                                    #-:lispworks7+
                                     (usocket:socket-stream
                                      (usocket:socket-connect host port
                                                              :element-type 'octet
@@ -607,14 +607,14 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
               (when (and use-ssl
                          ;; don't attach SSL to existing streams
                          (not stream))
-                #+:lispworks7.1
+                #+:lispworks7+
                 (comm:attach-ssl http-stream
                                  :ssl-side :client
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  :tlsext-host-name
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  (puri:uri-host uri))
-                #-:lispworks7.1
+                #-:lispworks7+
                 (setq http-stream (make-ssl-stream http-stream
                                                    :hostname (puri:uri-host uri)
                                                    :certificate certificate
@@ -648,14 +648,14 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 ;; got a connection; we have to read a blank line,
                 ;; turn on SSL, and then we can transmit
                 (read-line* http-stream)
-                #+:lispworks7.1
+                #+:lispworks7+
                 (comm:attach-ssl raw-http-stream
                                  :ssl-side :client
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  :tlsext-host-name
                                  #-(or lispworks4 lispworks5 lispworks6)
                                  (puri:uri-host uri))
-                #-:lispworks7.1
+                #-:lispworks7+
                 (setq http-stream (wrap-stream
                                    (make-ssl-stream raw-http-stream
                                                     :hostname (puri:uri-host uri)

--- a/util.lisp
+++ b/util.lisp
@@ -295,7 +295,7 @@ which are not meant as separators."
          (setq cookie-start (1+ end-pos))
          (go next-cookie))))))
 
-#-:lispworks7.1
+#-:lispworks7+
 (defun make-ssl-stream (http-stream &key certificate key certificate-password verify (max-depth 10) ca-file ca-directory
                                          hostname)
   "Attaches SSL to the stream HTTP-STREAM and returns the SSL stream


### PR DESCRIPTION
This change fixes up the LispWorks checks that were looking for LispWorks 7.1 to look for LispWorks 7+, fixing drakma for LispWorks 8.x.

Tested against LW8.0 (macOS Ventura 13.1 arm64), LW7.1 (as much as possible under macOS 13.1 arm64, changes to SSL libs make that challenging), sbcl 2.2.10 (macOS 13.1 arm64).