### PR TITLE
Fix #'HEADER-VALUE to support strings

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -170,7 +170,8 @@ Returns TOKEN itself otherwise."
 and NAME is a keyword naming a header, this function returns the
 corresponding value of this header \(or NIL if it's not in
 HEADERS)."
-  (cdr (assoc name headers :test #'eq)))
+  (cdr (assoc name headers :test
+              (etypecase name (keyword #'eq) (string #'equalp)))))
 
 (defun parameter-present-p (name parameters)
   "If PARAMETERS is an alist of parameters as returned by, for


### PR DESCRIPTION
Recent commits to Chunga have modified the interning behavior, to prevent a memory leak when servers use pseudorandom names for response headers (see #140 and edicl/chunga#11).

This commit updates the matching behavior to support unknown headers provided as strings. It does not support matching keywords against strings, nor vice versa; it could be a flexibility improvement to support that, for use when interactively discovering the set of desired headers for interning.