### PR TITLE
Close socket with :abort T after error

### DIFF
--- a/request.lisp
+++ b/request.lisp
@@ -909,9 +909,7 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                   (return-from http-request #'finish-request))
                 (finish-request content)))))
         ;; the cleanup form of the UNWIND-PROTECT above
-        (when (and http-stream
-                   (or (not done)
-                       (and must-close
-                            (not want-stream)))
-                   (not (eq content :continuation)))
-          (ignore-errors (close http-stream)))))))
+        (when (and http-stream (not (eq content :continuation)))
+          (flet ((close-aborting (abort) (ignore-errors (close http-stream :abort abort))))
+            (cond ((not done) (close-aborting t))
+                  ((and must-close (not want-stream)) (close-aborting nil)))))))))


### PR DESCRIPTION
clisp (or less likely usocket) doesn't allow socket operations, other than close, after an error; it exits with code 141.  CL+SSL might produce an error e.g. during implicit force-outputs. DRAKMA's http-request then calls its close method in an unwind-protect cleanup form, which calls force-output again. This second call causes clisp to exit.  The following semantics for close seem sensible: If you've received an error operating with a plain-text or CL+SSL socket, then call close with :abort T. Use :abort NIL only when you've encountered no errors. When close is used that way, the problem gets solved. CL+SSL's close doesn't call force-output when :abort is T.