### PR TITLE
Encode {PROXY-,}BASIC-AUTHORIZATION using the default external format

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -935,6 +935,8 @@ T</span>
             <code>NIL</code>, should be a list of two strings
             (username and password) which will be sent to the server
             for basic authorization.
+            Its encoding is affected by
+            <code xmlns=""><i>*drakma-default-external-format*</i></code>.
           </p>
           <p xmlns="http://www.w3.org/1999/xhtml">
             <a name="arg-user-agent"></a>
@@ -972,6 +974,8 @@ T</span>
             denoting the port to use (which will default to 80
             otherwise).  Defaults to
             <code xmlns=""><i>*default-http-proxy*</i></code>.
+            Its encoding is affected by
+            <code xmlns=""><i>*drakma-default-external-format*</i></code>.
             <code xmlns=""><i>proxy-basic-authorization</i></code> is used
             like <code xmlns=""><i>basic-authorization</i></code>, but for the
             proxy, and only if <code xmlns=""><i>proxy</i></code> is true.  If

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -608,7 +608,7 @@ T</span>
     </p>
     <p>
       The canonical location for the latest version of Drakma is <a
-      href="http://weitz.de/files/drakma.tar.gz">http://weitz.de/files/drakma.tar.gz</a>.
+      href="https://github.com/edicl/drakma/releases">https://github.com/edicl/drakma/releases</a>.
     </p>
   </clix:chapter>
 
@@ -915,6 +915,8 @@ T</span>
             <code>NIL</code>, should be a list of two strings
             (username and password) which will be sent to the server
             for basic authorization.
+            Its encoding is affected by
+            <clix:arg>*drakma-default-external-format*</clix:arg>.
           </p>
           <p>
             <a name="arg-user-agent"/>
@@ -952,6 +954,8 @@ T</span>
             denoting the port to use (which will default to 80
             otherwise).  Defaults to
             <clix:arg>*default-http-proxy*</clix:arg>.
+            Its encoding is affected by
+            <clix:arg>*drakma-default-external-format*</clix:arg>.
             <clix:arg>proxy-basic-authorization</clix:arg> is used
             like <clix:arg>basic-authorization</clix:arg>, but for the
             proxy, and only if <clix:arg>proxy</clix:arg> is true.  If

--- a/request.lisp
+++ b/request.lisp
@@ -712,16 +712,20 @@ Any encodings in Transfer-Encoding, such as chunking, are always performed."
                 (write-header "User-Agent" "~A" (user-agent-string user-agent)))
               (when basic-authorization
                 (write-header "Authorization" "Basic ~A"
-                              (base64:string-to-base64-string
-                               (format nil "~A:~A"
-                                       (first basic-authorization)
-                                       (second basic-authorization)))))
+                              (base64:usb8-array-to-base64-string
+                               (string-to-octets
+                                (format nil "~A:~A"
+                                        (first basic-authorization)
+                                        (second basic-authorization))
+                                :external-format *drakma-default-external-format*))))
               (when (and proxy proxy-basic-authorization)
                 (write-header "Proxy-Authorization" "Basic ~A"
-                              (base64:string-to-base64-string
-                               (format nil "~A:~A"
-                                       (first proxy-basic-authorization)
-                                       (second proxy-basic-authorization)))))
+                              (base64:usb8-array-to-base64-string
+                               (string-to-octets
+                                (format nil "~A:~A"
+                                        (first proxy-basic-authorization)
+                                        (second proxy-basic-authorization))
+                                :external-format *drakma-default-external-format*))))
               (when accept
                 (write-header "Accept" "~A" accept))
               (when range


### PR DESCRIPTION
Fixes #152

Also fixed an inconsistency between the docs XML/HTML files.